### PR TITLE
Mask wait online services and fix repos input

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build-prep:
     runs-on: ubuntu-24.04-arm
+    outputs:
+      include_packagecloud_dev: ${{ steps.set_vars.outputs.include_packagecloud_dev }}
     steps:
       - name: Check if inputs choice exists
         run: |
@@ -23,12 +25,13 @@ jobs:
           fi
           echo "REPOS=$CHOICE" >> $GITHUB_ENV
       - name: Set repos choice variable
+        id: set_vars
         run: |
           echo "Repos choice: $REPOS"
           if [ "$REPOS" = "both" ]; then
-            echo 'include_packagecloud_dev=1' >> $GITHUB_OUTPUT
+            echo "include_packagecloud_dev=1" >> $GITHUB_OUTPUT
           else
-            echo 'include_packagecloud_dev=0' >> $GITHUB_OUTPUT
+            echo "include_packagecloud_dev=0" >> $GITHUB_OUTPUT
           fi
   build-image:
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,9 @@ jobs:
         run: |
           echo "Repos choice: $REPOS"
           if [ "$REPOS" = "both" ]; then
-            echo 'INCLUDE_PACKAGECLOUD_DEV=1' >> $GITHUB_OUTPUT
+            echo 'include_packagecloud_dev=1' >> $GITHUB_OUTPUT
           else
-            echo 'INCLUDE_PACKAGECLOUD_DEV=0' >> $GITHUB_OUTPUT
+            echo 'include_packagecloud_dev=0' >> $GITHUB_OUTPUT
           fi
   build-image:
     runs-on: ubuntu-24.04-arm
@@ -70,7 +70,7 @@ jobs:
         env:
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
-          sudo ./build.sh
+          sudo ./build.sh --include_packagecloud_dev=${{ needs.build-prep.outputs.include_packagecloud_dev }}
       - name: Get current date
         id: date
         run: echo "date=$(date -u +'%Y%m%dt%H%M%S')" >> $GITHUB_ENV

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,20 @@
 #!/bin/bash -e
 
+include_packagecloud_dev="${include_packagecloud_dev:-1}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --include_packagecloud_dev=*)
+            include_packagecloud_dev="${1#*=}"
+            shift
+            ;;
+        *)
+            echo "Unknown parameter: $1"
+            exit 1
+            ;;
+    esac
+done
+
 # shellcheck disable=SC2119
 run_sub_stage()
 {
@@ -184,7 +199,8 @@ export IMG_DATE="${IMG_DATE:-"$(date +%Y%m%d-%H%M%S)"}"
 export IMG_FILENAME="${IMG_FILENAME:-"${IMG_NAME}-${IMG_DATE}"}"
 export ARCHIVE_FILENAME="${ARCHIVE_FILENAME:-"${IMG_NAME}-${IMG_DATE}"}"
 
-export INCLUDE_PACKAGECLOUD_DEV=${INCLUDE_PACKAGECLOUD_DEV:-1}
+export INCLUDE_PACKAGECLOUD_DEV="${include_packagecloud_dev}"
+echo "INCLUDE_PACKAGECLOUD_DEV is ${include_packagecloud_dev}"
 
 export SCRIPT_DIR="${BASE_DIR}/scripts"
 export WORK_DIR="${WORK_DIR:-"${BASE_DIR}/work/${IMG_NAME}"}"

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e
 
-include_packagecloud_dev="${include_packagecloud_dev:-1}"
-
 while [ $# -gt 0 ]; do
     case "$1" in
         --include_packagecloud_dev=*)
@@ -14,6 +12,8 @@ while [ $# -gt 0 ]; do
             ;;
     esac
 done
+
+include_packagecloud_dev="${include_packagecloud_dev:-1}"
 
 # shellcheck disable=SC2119
 run_sub_stage()

--- a/wlanpi0-base/02-net-tweaks/01-run.sh
+++ b/wlanpi0-base/02-net-tweaks/01-run.sh
@@ -25,5 +25,7 @@ fi
 
 on_chroot << EOF
 systemctl disable systemd-networkd-wait-online
+systemctl mask systemd-networkd-wait-online.service
 systemctl disable NetworkManager-wait-online.service
+systemctl mask NetworkManager-wait-online.service
 EOF


### PR DESCRIPTION
## Type of change 

<!--
Feel free to remove sections and items that don't pertain to the context of your PR.
For example, if you're updating docs, you don't need the testing section.
Note that you do not need to delete these HTML comments as they are not visible after the PR is submitted.
-->

<!-- *Pick at least one.* -->

* [X] Bug fix (non-breaking change that fixes something)

## Proposed change

<!-- *Please describe the purpose of this change, the problem it solves, and why the change is necessary. Including code snippets or links to related documentation when applicable will assist approval.* -->

This PR fixes the repos input in the workflow file.

![image](https://github.com/user-attachments/assets/b91332f2-37e4-4b6b-ac21-b285511909b9)

The `both` option will include wlanpi/main + wlanpi/dev packagecloud repos

The `main` option will only include wlanpi/main.

![image](https://github.com/user-attachments/assets/7149f8b2-ba27-4822-ad9a-010983e8aa0e)

This PR also attempts to stop and mask NetworkManager and systemd-networkd wait-online services from delaying startup.

## Testing

<!-- *Please explain how you tested this change manually, and if applicable, what new tests you added.* -->

Tested repos input works in my fork.

Tested build from my fork and confirmed `getjwt josh` worked right away after login.

## Checklist

<!-- No PR without a related GH issue! Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, homing pigeon, or slack are great starting points, but **do not count** for this requirement. --> 

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)