### PR TITLE
[CHORE] standardize version format to use hyphens instead of underscores and tildes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,12 @@ on:
         default: false
 
       rc_tag:
-        description: '🔄 PROMOTE: a specific RC: requires full git tag (format is YYYY.MM.DD_rc.N e.g., 2025.04.18_rc.1)'
+        description: '🔄 PROMOTE: a specific RC: requires full git tag (format is YYYY.MM.DD-rc.N e.g., 2025.04.19-rc.1)'
         required: false
         type: string
         
       base_date:
-        description: '🔄/🔨 PROMOTE/BUILD: override todays date (format: YYYY.MM.DD, e.g., 2025.04.18) to continue incremental versioning'
+        description: '🔄/🔨 PROMOTE/BUILD: override todays date (format: YYYY.MM.DD, e.g., 2025.04.19) to continue incremental versioning'
         required: false
         type: string
 
@@ -63,7 +63,7 @@ on:
         default: 'AB'
 
       point_base:
-        description: '🔨 BUILD: for point releases (2025.04.18.1): specify base to create patch release for (e.g., 2025.04.18)'
+        description: '🔨 BUILD: for point releases (2025.04.19.1): specify base to create patch release for (e.g., 2025.04.19)'
         required: false
         type: string
 permissions:
@@ -172,7 +172,7 @@ jobs:
             if [ -f "$FILE" ]; then
               EXTENSION="${FILE##*.}"
               BASE_NAME=$(basename "$FILE" .$EXTENSION)
-              RC_PART=$(echo "$BASE_NAME" | grep -o '[0-9]\{4\}\.[0-9]\{2\}\.[0-9]\{2\}[_~]rc\.[0-9]*' || echo "")
+              RC_PART=$(echo "$BASE_NAME" | grep -o '[0-9]\{4\}\.[0-9]\{2\}\.[0-9]\{2\}-rc\.[0-9]*' || echo "")
               if [ -n "$RC_PART" ]; then
                 NEW_BASE_NAME="${BASE_NAME/$RC_PART/$FINAL_VERSION}"
                 NEW_NAME="$NEW_BASE_NAME.$EXTENSION"
@@ -254,6 +254,9 @@ jobs:
       - name: Set version variables
         id: version
         run: |
+          # Version format: YYYY.MM.DD-type.N-codename
+          # Example: 2025.04.19-dev.1-theanine
+
           CODENAME="${{ github.event.inputs.codename }}"
           echo "codename=$CODENAME" >> $GITHUB_OUTPUT
           if [ -n "${{ github.event.inputs.base_date }}" ]; then
@@ -281,19 +284,25 @@ jobs:
           elif [ "$BUILD_TYPE" = "final" ]; then
             VERSION="$BASE_VERSION"
           else
+            LATEST_SEQ=$(git tag -l "${BASE_VERSION}-${BUILD_TYPE}.*" | sort -V | tail -n1)
+
+            echo "Looking for existing tags with pattern:"
+            echo "${BASE_VERSION}-${BUILD_TYPE}.*"
+
+            # For backward compatibility during transition, also check old patterns
             LATEST_SEQ_UNDERSCORE=$(git tag -l "${BASE_VERSION}_${BUILD_TYPE}.*" | sort -V | tail -n1)
             LATEST_SEQ_TILDE=$(git tag -l "${BASE_VERSION}~${BUILD_TYPE}.*" | sort -V | tail -n1)
-            
-            echo "Looking for existing tags with patterns:"
-            echo "${BASE_VERSION}_${BUILD_TYPE}.*"
-            echo "${BASE_VERSION}~${BUILD_TYPE}.*"
-            
-            if [ -n "$LATEST_SEQ_UNDERSCORE" ]; then
+
+            if [ -n "$LATEST_SEQ" ]; then
+              echo "Found tag with hyphen: $LATEST_SEQ"
+            elif [ -n "$LATEST_SEQ_UNDERSCORE" ]; then
               echo "Found tag with underscore: $LATEST_SEQ_UNDERSCORE"
               LATEST_SEQ="$LATEST_SEQ_UNDERSCORE"
+              echo "Converting underscore format to hyphen format for next version"
             elif [ -n "$LATEST_SEQ_TILDE" ]; then
               echo "Found tag with tilde: $LATEST_SEQ_TILDE"
               LATEST_SEQ="$LATEST_SEQ_TILDE"
+              echo "Converting tilde format to hyphen format for next version"
             else
               echo "No existing tags found"
               LATEST_SEQ=""
@@ -303,13 +312,8 @@ jobs:
               SEQ_NUM=1
               echo "Starting new sequence with number 1"
             else
-              if [[ "$LATEST_SEQ" == *"_$BUILD_TYPE."* ]]; then
-                # For tags with underscore format: 2025.04.18_dev.1-theanine
-                CURR_SEQ=$(echo "$LATEST_SEQ" | grep -o "_$BUILD_TYPE\.[0-9]*" | cut -d. -f2)
-              else
-                # For tags with tilde format: 2025.04.18~dev.1-theanine
-                CURR_SEQ=$(echo "$LATEST_SEQ" | grep -o "~$BUILD_TYPE\.[0-9]*" | cut -d. -f2)
-              fi
+              # For tags with hyphen format: 2025.04.19-dev.1-theanine
+              CURR_SEQ=$(echo "$LATEST_SEQ" | grep -o "-$BUILD_TYPE\.[0-9]*" | cut -d. -f2)
               
               if [ -z "$CURR_SEQ" ]; then
                 echo "Failed to extract sequence number from $LATEST_SEQ, defaulting to 1"
@@ -321,8 +325,7 @@ jobs:
               fi
             fi
             
-            # Always use tilde in the VERSION but the tag will convert to underscore
-            VERSION="${BASE_VERSION}~${BUILD_TYPE}.${SEQ_NUM}"
+            VERSION="${BASE_VERSION}-${BUILD_TYPE}.${SEQ_NUM}"
           fi
           FULL_VERSION="${VERSION}-${CODENAME}"
           echo "Version: $BASE_VERSION"
@@ -797,7 +800,7 @@ jobs:
       - name: Prepare git tag from version for pre-release
         run: |
           VERSION="${{ needs.build-prep.outputs.full_version }}"
-          GIT_TAG=$(echo "$VERSION" | sed 's/~/\_/g')
+          GIT_TAG="$VERSION"
           echo "Using git tag: $GIT_TAG"
           echo "git_tag=$GIT_TAG" >> $GITHUB_ENV
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -793,6 +793,7 @@ jobs:
           find all-artifacts -name "*.img.gz" -exec cp {} release-files/ \;
           find all-artifacts -name "*.sha256" -exec cp {} release-files/ \;
           find all-artifacts -name "*.info" -exec cp {} release-files/ \;
+          find all-artifacts -name "*.sbom.xz" -exec cp {} release-files/ \;
           
           echo "Release files prepared:"
           ls -la release-files/

--- a/README.md
+++ b/README.md
@@ -1,127 +1,94 @@
-# wlan(pi-gen)
+# WLAN Pi OS builder (bookworm)
 
-Tool used to create WLAN Pi OS images for bookworm.
+Tool based on pi-gen to generate WLAN Pi OS images for bookworm.
 
 ## WLAN Pi OS versioning
 
-Format: `YYYY.MM.DD[~type.sequence][.point]-CODENAME`
+Format: `YYYY.MM.DD[-type.sequence][.point]-CODENAME`
 
 ```
 Release version format: YYYY.MM.DD-codename
 Point releases: Rare, using YYYY-MM-DD.P-codename format
 Codenames: Coffee themed starting with 'Affogato' for releases. Development releases should be using 'theanine' as default codename.
-Pre-release markers: ~dev, ~rc
-Dev builds: YYYY.MM.DD~dev.seq-codename
-Release candidates: YYYY.MM.DD~rc.seq-codename
+Pre-release markers: -dev, -rc
+Dev builds: YYYY.MM.DD-dev.seq-codename
+Release candidates: YYYY.MM.DD-rc.seq-codename
 Development track: Infrequent
-Testing approach: ~dev releases until an ~rc is cut
+Testing approach: -dev releases until an -rc is cut
 Release cadence: Irregular (as needed)
 ```
 
 Codenames:
 
-Stored in `/etc/os-release`
+- Stored in `/etc/os-release`
 
+Version:
+
+- Stored in `/etc/wlanpi-release`
+  
 Examples:
 
 ```
-2025.04.17~dev.1  (First development build on April 4, 2025)
-2025.04.17~dev.2  (Second development build on same day)
-2025.04.17~rc.1   (First release candidate)
+2025.04.19-dev.1  (First development build on April 4, 2025)
+2025.04.19-dev.2  (Second development build on same day)
+2025.04.19-rc.1   (First release candidate)
 [Testing period of 6 days]
-2025.04.17        (Final release promoted on April 10)
-2025.04.17.1      (Point release/hotfix if needed)
+2025.04.19        (Final release promoted on April 10)
+2025.04.19.1      (Point/patch/hotfix release if needed)
 ```
 
 ## WLAN Pi OS versioning guidelines
 
 ### Version Structure
 
-- Format: YYYY.MM.DD[~type.sequence][.point]
-  - YYYY.MM.DD: Base date (e.g., 2025.04.17)
-  - ~type: Optional pre-release type (~dev or ~rc)
+- Format: YYYY.MM.DD[-type.sequence][.point]
+  - YYYY.MM.DD: Base date (e.g., 2025.04.19)
+  - -type: Optional pre-release type (-dev or -rc)
   - .seq: Sequential number for same-day builds (1, 2, 3...)
   - .P: Optional point release number for hotfixes (rare)
 
 ### Version Types
 
-1. Development builds: `YYYY.MM.DD~dev.seq`
+1. Development builds: `YYYY.MM.DD-dev.seq`
    - For developer testing and feature development
-   - Example: 2025.04.17~dev.1
+   - Example: 2025.04.19-dev.1
 
-2. Release candidates: `YYYY.MM.DD~rc.seq`
+2. Release candidates: `YYYY.MM.DD-rc.seq`
    - For wider testing before final release
-   - Example: 2025.04.17~rc.1
+   - Example: 2025.04.19-rc.1
 
 3. Final releases: `YYYY.MM.DD`
    - Official stable releases
-   - Example: 2025.04.17
+   - Example: 2025.04.19
 
 4. Point releases: `YYYY.MM.DD.P`
    - For emergency fixes or minor updates same day
-   - Example: 2025.04.17.1
+   - Example: 2025.04.19.1
 
 ## Implementation Requirements
 
-1. Build system must:
+1. Build system:
 
-   - Use current ISO 8601 date for the base version separated by periods.
-   - Track and increment sequence numbers for same-day builds through git tags replacing the tilde with an underscore to avoid conflicts with git branch names.
-   - Apply correct type marker based on build intention
+   - Use current ISO 8601 date (YYYY.MM.DD) for the base version separated by periods.
+   - Track and increment sequence numbers for same-day builds through git tags.
+   - Apply correct image type marker based on build intention.
 
 2. Release promotion path:
 
    - Development → RC → Final Release
-   - Final RC build should be promotable to final Release without rebuild
-   - No mechanism to promote from ~dev to ~rc. Promotion mechanism for ~rc to final only.
-   - Mechanism to strip ~rc marker when promoting to release
-   - Workflow allows current ISO 8601 date for base version by default, but allows a different base date which enables promoting an RC to release from any date to maintain the same versioning structure and format.
+   - Final RC build should be promotable to final release without rebuild
+   - No mechanism to promote from -dev to -rc. Promotion mechanism is for -rc to final only. -rc will remain in the filenames.
+   - Mechanism to strip -rc marker when promoting to release
+   - Workflow allows current ISO 8601 date (YYYY.MM.DD) for base version by default, but allows a different base date which enables promoting an -rc to release from any date to maintain the same versioning structure and format.
 
-3. File naming convention:
+3. File naming convention: wlanpi-os-TYPE-VERSION.img
+  
+   - Example: wlanpi-os-lite-2025.04.19-rc.1.img
+   - Example: wlanpi-os-full-2025.04.19-rc.1.img
 
-   - wlanpi-os-TYPE-VERSION.img.gz
-   - Example: wlanpi-os-lite-2025.04.17~rc.1.img.gz
-   - Example: wlanpi-os-full-2025.04.17~rc.1.img.gz
+4. Others
 
-4. Version identification:
-
-   - Include version string in the OS itself
-   - Provide /etc/wlanpi-release with contents VERSION=<version> with no trailing white characters and no quotes around <version>.
-
-5. Release notes
-
-   - Document changes between versions into automatically created release notes.
-   - Downstream files included need to be stored in an wlanpi-os-TYPE-VERISON.packages text file and used to compare against.
-   - Clarify which previous version a build is based on
-   - Include SHA checksums for verification of every file generated for all files in a digest file using the filename wlanpi-os-TYPE-VERSION.digests
-
-## Version Management
-
-- Track sequence numbers via git tags
-- Store latest sequence number for each build type in the git tag
-- Reset sequence numbers at date change
-- Use GitHub releases and tags for version management and tracking between releases and release types.
-
-## GHA example ideas
-
-```
-release_type:
-  description: 'Release type'
-  required: true
-  default: 'dev'
-  type: choice
-  options:
-    - dev
-    - rc
-    - promote
-    - final
-    - point
-
-point_base:
-  description: 'Base version for point release (e.g., 2025.04.17)'
-  required: false
-  type: string
-```
+   - Release files include info showing what is installed, sbom, and digests including sha256sums of image files.
 
 ## Original Readme
 


### PR DESCRIPTION
## Type of change 

<!--
Feel free to remove sections and items that don't pertain to the context of your PR.
For example, if you're updating docs, you don't need the testing section.
Note that you do not need to delete these HTML comments as they are not visible after the PR is submitted.
-->


This PR standardizes the WLAN Pi OS version format to use hyphens (-) for separating version components, replacing the previous mix of underscores (_) and tildes (~). This brings more consistency to our versioning schema.

<!-- *Pick at least one.* -->

* [X] Bug fix (non-breaking change that fixes something)
* [X] Documentation update (readme, changelog, man page, etc.)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature changing existing functionality)
* [X] Code quality improvement (refactor, performance improvements)
* [ ] Other (please specify):

## Breaking change

<!-- *Does this Pull Request introduce a breaking change?* -->

- What functionality breaks?
- Why does it break?
- How should it be migrated?  
- Are there any backward-compatible alternatives?

## Proposed change

<!-- *Please describe the purpose of this change, the problem it solves, and why the change is necessary. Including code snippets or links to related documentation when applicable will assist approval.* -->

- Replace format `YYYY.MM.DD_rc.N` with `YYYY.MM.DD-rc.N` for release candidates
- Replace format `YYYY.MM.DD~dev.N` with `YYYY.MM.DD-dev.N` for development builds
- Update version parsing logic to handle both old and new formats during transition
- Update all examples and documentation to reflect the new format
- Add *.sbom.xz release files 

Before:

- `2025.04.19_rc.1` → after: `2025.04.19-rc.1`
- `2025.04.19~dev.1` → after: `2025.04.19-dev.1`

## Testing

<!-- *Please explain how you tested this change manually, and if applicable, what new tests you added.* -->

The build workflow includes backwards compatibility to handle the transition:

- Detects and parses both old underscore/tilde formats and new hyphen format
- Automatically upgrades to hyphen format when creating new versions
- Maintains compatibility with existing tags during the migration period
- Tested in my fork

## Checklist

<!-- No PR without a related GH issue! Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, homing pigeon, or slack are great starting points, but **do not count** for this requirement. --> 

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [ ] I ran the test suite and verified it succeeded
* [X] I linked a GitHub issue to this PR (in the next section). 
* [ ] I have updated the changelog (if applicable)
* [X] I have added or updated the documentation (if applicable)

## Related Issues/PRs

<!-- *Pick at least one. Delete the other lines.* -->

- This PR closes issue #25 