### PR TITLE
[FIX] Add safety checks to prevent ufw lockout during first boot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,12 +312,22 @@ jobs:
               SEQ_NUM=1
               echo "Starting new sequence with number 1"
             else
+              set -o pipefail
+              
               # For tags with hyphen format: 2025.04.19-dev.1-theanine
-              CURR_SEQ=$(echo "$LATEST_SEQ" | grep -o -E "-${BUILD_TYPE}\.[0-9]+" | sed "s/-${BUILD_TYPE}\.//" )
+              CURR_SEQ=$(echo "$LATEST_SEQ" | grep -o -E -- "-${BUILD_TYPE}\.[0-9]+" | sed "s/-${BUILD_TYPE}\.//" )
+              EXIT_STATUS=$?
+              
+              set +o pipefail
+              
+              if [ $EXIT_STATUS -ne 0 ]; then
+                echo "Error: Failed to process sequence number from $LATEST_SEQ"
+                exit 1
+              fi
               
               if [ -z "$CURR_SEQ" ]; then
-                echo "Failed to extract sequence number from $LATEST_SEQ, defaulting to 1"
-                SEQ_NUM=1
+                echo "Error: Failed to extract sequence number from $LATEST_SEQ"
+                exit 1
               else
                 echo "Current sequence number: $CURR_SEQ"
                 SEQ_NUM=$((CURR_SEQ + 1))

--- a/wlanpi1-lite/10-first-boot/files/usr/bin/first-boot.sh
+++ b/wlanpi1-lite/10-first-boot/files/usr/bin/first-boot.sh
@@ -2,16 +2,24 @@
 
 set -e 
 
+raspi-config nonint do_wifi_country US || echo "WARNING: failed to set country code"
+
+echo '#!/bin/sh
+echo "Welcome to WLAN Pi OS. This device is intended for educational, laboratory, and non-commercial testing purposes. WLAN Pi provides ABSOLUTELY NO WARRANTY. You are solely responsible for complying with applicable laws and regulations."' > /etc/update-motd.d/20-wlanpi-legal
+chmod +x /etc/update-motd.d/20-wlanpi-legal
+
 if ! command -v ufw >/dev/null 2>&1; then
     echo "ufw not found ..."
 else
-    ufw --force reset
-
+    # ensure UFW is configured
     ufw default deny incoming
     ufw default allow outgoing
+    
+    ssh_rule_added=false
 
+    # SSH
     ufw allow 22/tcp
-
+    
     # oscium-spectrum
     ufw allow 3264/tcp
     ufw allow 3264/udp
@@ -23,7 +31,7 @@ else
     # DHCP server
     ufw allow 67/udp
 
-    # Ephemeral/avahi-related port
+    # ephemeral/avahi-related port
     ufw allow 36872/udp
 
     # mDNS (IPv4 multicast)
@@ -32,20 +40,25 @@ else
     # mDNS (IPv6 link-local multicast)
     ufw allow proto udp from fe80::/10 to any port 5353
 
-    # web access and WLAN Pi API
-    ufw allow 80/tcp      # HTTP
-    ufw allow 443/tcp     # HTTPS
-    ufw allow 8081/tcp    # Alt web UI
-    ufw allow 31415/tcp   # WLAN Pi API
-
     ufw logging on
-    ufw --force enable
+
+    if ! ufw status verbose | grep -q "22/tcp.*ALLOW"; then
+        echo "WARNING: SSH rule not properly added ... retrying ..."
+        ufw delete allow 22/tcp 2>/dev/null || true
+        if ufw allow 22/tcp; then
+            ssh_rule_added=true
+        fi
+    else
+        ssh_rule_added=true
+    fi
+
+    if [[ "$ssh_rule_added" == true ]]; then
+        ufw --force enable
+        echo "ufw enabled after force ..."
+    else
+        echo "WARNING: SSH not in firewall rules. ufw not enabled to prevent lockout ..."
+        exit 1
+    fi
 fi
-
-raspi-config nonint do_wifi_country US
-
-echo '#!/bin/sh
-echo "Welcome to WLAN Pi OS. This device is intended for educational, laboratory, and non-commercial testing purposes. WLAN Pi provides ABSOLUTELY NO WARRANTY. You are solely responsible for complying with applicable laws and regulations."' > /etc/update-motd.d/20-wlanpi-legal
-chmod +x /etc/update-motd.d/20-wlanpi-legal
 
 exit 0

--- a/wlanpi1-lite/19-ab-scripts/00-run.sh
+++ b/wlanpi1-lite/19-ab-scripts/00-run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+install -v -m 755 files/commit_current_partition "${ROOTFS_DIR}/usr/local/sbin/"
+install -v -m 755 files/go-serial2json.sh "${ROOTFS_DIR}/usr/local/sbin/"
+install -v -m 755 files/go-device-info-decoder.sh "${ROOTFS_DIR}/usr/local/sbin/"

--- a/wlanpi1-lite/19-ab-scripts/files/boot-info
+++ b/wlanpi1-lite/19-ab-scripts/files/boot-info
@@ -1,0 +1,117 @@
+#!/bin/bash
+#
+# boot-info
+# A/B partition boot debug script
+# This script provides detailed information about the current boot state
+#
+# Version: v0.1
+# Author: Josh Schmelzle
+# License: BSD-3
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: need elevated permissions ... run as root (sudo) ..."
+    exit 1
+fi
+
+echo_warning() {
+    echo -e "\e[1;31mWARNING: $1\e[0m"
+}
+
+echo_error() {
+    echo -e "\e[1;31mERROR: $1\e[0m"
+    exit 1
+}
+
+echo_status() {
+    echo -e "\e[1;34m>>> $1\e[0m"
+}
+
+echo_debug() {
+    echo -e "\e[1;33mDEBUG: $1\e[0m"
+}
+
+echo_status "A/B Partition Boot Investigation"
+
+echo_debug "System Information:"
+uname -a | sed 's/^/    /'
+
+echo_debug "Model Information:"
+cat /proc/device-tree/model | sed 's/^/    /' || echo "    [Could not read model]"
+echo ""
+
+echo_debug "Current Partition Set Analysis:"
+CURRENT_BOOT_DEV=$(findmnt -n -o SOURCE /boot)
+CURRENT_ROOT_DEV=$(findmnt -n -o SOURCE /)
+
+# Updated partition check logic for new layout
+if [[ "$CURRENT_BOOT_DEV" == "/dev/mmcblk0p1" && "$CURRENT_ROOT_DEV" == "/dev/mmcblk0p5" ]]; then
+    echo "    Currently using partition set A (boot from p1, root from p5)"
+elif [[ "$CURRENT_BOOT_DEV" == "/dev/mmcblk0p2" && "$CURRENT_ROOT_DEV" == "/dev/mmcblk0p6" ]]; then
+    echo "    Currently using partition set B (boot from p2, root from p6)"
+else
+    echo "    WARNING: Mixed partition usage!"
+    echo "    Boot from: $CURRENT_BOOT_DEV"
+    echo "    Root from: $CURRENT_ROOT_DEV"
+fi
+
+echo_debug "Current /etc/fstab contents:"
+cat /etc/fstab | sed 's/^/    /'
+
+echo_debug "Mount Points:"
+mount | grep mmcblk0 | sed 's/^/    /'
+
+echo_debug "Current Boot Partition Contents:"
+ls -la /boot | sed 's/^/    /'
+
+echo_debug "cmdline.txt contents:"
+cat /boot/cmdline.txt | sed 's/^/    /'
+
+echo_debug "Contents of /boot/cmdline-b.txt:"
+if [ -f "/boot/cmdline-b.txt" ]; then
+    cat /boot/cmdline-b.txt | sed 's/^/    /'
+else
+    echo "    [File does not exist]"
+fi
+
+echo_debug "Contents of /boot/tryboot.txt:"
+if [ -f "/boot/tryboot.txt" ]; then
+    cat /boot/tryboot.txt | sed 's/^/    /'
+else
+    echo "    [File does not exist]"
+fi
+
+echo_debug "Contents of /boot/autoboot.txt:"
+if [ -f "/boot/autoboot.txt" ]; then
+    cat /boot/autoboot.txt | sed 's/^/    /'
+else
+    echo "    [File does not exist]"
+fi
+
+echo_debug "Partition layout:"
+lsblk -o NAME,SIZE,MOUNTPOINT,FSTYPE,LABEL,UUID,PARTUUID | sed 's/^/    /'
+
+echo_debug "Partition flags:"
+parted /dev/mmcblk0 print | sed 's/^/    /'
+
+echo_debug "Partition usage statistics:"
+df -h | grep mmcblk0 | sed 's/^/    /'
+
+echo_debug "Kernel command line used:"
+cat /proc/cmdline | sed 's/^/    /'
+
+echo_debug "Boot history (last 5 boots):"
+journalctl --list-boots | head -5 | sed 's/^/    /'
+
+echo_debug "Boot messages related to mmc/partitions:"
+dmesg | grep -i -e mmc -e partition -e boot | head -20 | sed 's/^/    /'
+
+echo_debug "Bootloader version:"
+vcgencmd bootloader_version | sed 's/^/    /'
+
+echo_debug "Summary:"
+echo "    Currently on partition set: $(if [[ "$CURRENT_BOOT_DEV" == "/dev/mmcblk0p1" ]]; then echo "A"; else echo "B"; fi)"
+echo "    Boot partition: $CURRENT_BOOT_DEV ($(df -h $CURRENT_BOOT_DEV | tail -1 | awk '{print $5}') used)"
+echo "    Root partition: $CURRENT_ROOT_DEV ($(df -h $CURRENT_ROOT_DEV | tail -1 | awk '{print $5}') used)"
+echo "    Default boot set in autoboot.txt: $(if grep -q "boot_partition=1" /boot/autoboot.txt; then echo "A"; else echo "B"; fi)"
+
+echo_status "Investigation complete!"

--- a/wlanpi1-lite/19-ab-scripts/files/commit-current-partition
+++ b/wlanpi1-lite/19-ab-scripts/files/commit-current-partition
@@ -1,0 +1,92 @@
+#!/bin/bash -e
+#
+# commit-current-partition - make current partition boot/root set the default
+#
+# Run this after a successful tryboot test to make the current partition permanent
+#
+#   e.g., sudo reboot "2 tryboot" for A to B; works?; then this script
+#   e.g., sudo reboot "1 tryboot" for B to A; works?; then this script
+#
+# Requires: mount
+#
+# Version: v0.1
+# Author: Josh Schmelzle
+# License: BSD-3
+
+echo_status() {
+    echo -e "\e[1;34m>>> $1\e[0m"
+}
+
+echo_debug() {
+    echo -e "\e[1;33mDEBUG: $1\e[0m"
+}
+
+echo_warning() {
+    echo -e "\e[1;31mWARNING: $1\e[0m"
+}
+
+echo_error() {
+    echo -e "\e[1;31mERROR: $1\e[0m"
+    exit 1
+}
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo_error "Need elevated permissions ... run as root (sudo) ..."
+fi
+
+echo_status "Starting partition commit process ..."
+
+CURRENT_ROOT=$(mount | grep ' on / ' | awk '{print $1}')
+CURRENT_BOOT=$(mount | grep ' on /boot ' | awk '{print $1}')
+echo_debug "Current root: $CURRENT_ROOT"
+echo_debug "Current boot: $CURRENT_BOOT"
+
+if [[ $CURRENT_ROOT == *"mmcblk0p5"* && $CURRENT_BOOT == *"mmcblk0p1"* ]]; then
+    echo_debug "Currently on partition set A (boot p1, root p5)"
+    CURRENT_SET="A"
+    CURRENT_BOOT_NUM=1
+elif [[ $CURRENT_ROOT == *"mmcblk0p6"* && $CURRENT_BOOT == *"mmcblk0p2"* ]]; then
+    echo_debug "Currently on partition set B (boot p2, root p6)"
+    CURRENT_SET="B"
+    CURRENT_BOOT_NUM=2
+else
+    echo_warning "Detected mixed partition usage!"
+    echo_debug "Root from: $CURRENT_ROOT"
+    echo_debug "Boot from: $CURRENT_BOOT"
+
+    if [[ $CURRENT_BOOT == *"mmcblk0p1"* ]]; then
+        CURRENT_BOOT_NUM=1
+        echo_debug "Using boot partition 1"
+    elif [[ $CURRENT_BOOT == *"mmcblk0p2"* ]]; then
+        CURRENT_BOOT_NUM=2
+        echo_debug "Using boot partition 2"
+    else
+        echo_error "Unable to determine boot partition number"
+    fi
+fi
+
+echo_status "Committing to current partition set ..."
+
+if [ -f "/boot/autoboot.txt" ]; then
+    echo_debug "Current autoboot.txt content:"
+    cat /boot/autoboot.txt | sed 's/^/    /'
+else
+    echo_debug "autoboot.txt does not exist, will create it"
+fi
+
+echo_debug "Updating autoboot.txt to make current partition set permanent ..."
+cat > /boot/autoboot.txt << EOF
+boot_partition=$CURRENT_BOOT_NUM
+tryboot_a_b=1
+EOF
+
+echo_debug "New autoboot.txt content:"
+cat /boot/autoboot.txt | sed 's/^/    /'
+
+echo_status "Partition commit complete"
+echo_debug "Partition set $CURRENT_SET is now the default boot option"
+echo_debug "This configuration will persist across all future reboots"
+echo ""
+echo_debug "To switch back to the other partition set, you can:"
+echo "1. Run: sudo switch_partitions.sh"
+echo "2. Then reboot: sudo reboot"

--- a/wlanpi1-lite/19-ab-scripts/files/switch-partition
+++ b/wlanpi1-lite/19-ab-scripts/files/switch-partition
@@ -1,0 +1,72 @@
+#!/bin/bash -e
+# switch-partition - switch between A/B partition sets
+#
+# Simply switches between partition sets without imaging
+#
+# Requires: mount sed
+#
+# Version: v0.1
+# Author:  Josh Schmelzle
+# License: BSD-3
+
+echo_status() {
+    echo -e "\e[1;34m>>> $1\e[0m"
+}
+
+echo_debug() {
+    echo -e "\e[1;33mDEBUG: $1\e[0m"
+}
+
+echo_warning() {
+    echo -e "\e[1;31mWARNING: $1\e[0m"
+}
+
+echo_error() {
+    echo -e "\e[1;31mERROR: $1\e[0m"
+    exit 1
+}
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo_error "Need elevated permissions ... run as root (sudo) ..."
+fi
+
+echo_status "Starting A/B partition switch"
+
+CURRENT_ROOT=$(mount | grep ' on / ' | awk '{print $1}')
+echo_debug "Current root: $CURRENT_ROOT"
+
+if [[ $CURRENT_ROOT == *"mmcblk0p5"* ]]; then
+    echo_debug "Currently booted from A partition set (boot p1, root p5)"
+    ACTIVE_SET="A"
+    TARGET_SET="B"
+    ACTIVE_BOOT_NUM=1
+    TARGET_BOOT_NUM=2
+elif [[ $CURRENT_ROOT == *"mmcblk0p6"* ]]; then
+    echo_debug "Currently booted from B partition set (boot p2, root p6)"
+    ACTIVE_SET="B"
+    TARGET_SET="A"
+    ACTIVE_BOOT_NUM=2
+    TARGET_BOOT_NUM=1
+else
+    echo_error "Unable to determine current boot partition ...\nCurrent root: $CURRENT_ROOT"
+fi
+
+echo_status "Switching from partition set $ACTIVE_SET to partition set $TARGET_SET"
+
+echo_debug "Updating autoboot.txt on active boot partition..."
+cat > /boot/autoboot.txt << EOF
+boot_partition=$TARGET_BOOT_NUM
+tryboot_a_b=1
+EOF
+
+echo_debug "Verifying content of autoboot.txt:"
+cat /boot/autoboot.txt | sed 's/^/    /'
+
+echo_status "Partition switch complete"
+echo_debug "Next boot will use partition set $TARGET_SET"
+echo ""
+echo_debug "To enable the switch, reboot with:"
+echo "sudo reboot"
+echo ""
+echo_debug "If you need to revert without booting the other partition set:"
+echo "sudo bash -c 'echo \"boot_partition=$ACTIVE_BOOT_NUM\" > /boot/autoboot.txt'"

--- a/wlanpi1-lite/19-ab-scripts/files/update-inactive-partition
+++ b/wlanpi1-lite/19-ab-scripts/files/update-inactive-partition
@@ -1,0 +1,318 @@
+#!/bin/bash -e
+#
+# update-inactive-partition - Update inactive partition set from compressed OS image
+#
+# Works with limited space by streaming the compressed image directly to partitions
+#
+# Requires: gunzip dd blkid mount sed
+#
+# Version: v0.4
+# Author: Josh Schmelzle
+# License: BSD-3
+
+echo_status() {
+    echo -e "\e[1;34m>>> $1\e[0m"
+}
+
+echo_debug() {
+    echo -e "\e[1;33mDEBUG: $1\e[0m"
+}
+
+echo_warning() {
+    echo -e "\e[1;31mWARNING: $1\e[0m"
+}
+
+echo_error() {
+    echo -e "\e[1;31mERROR: $1\e[0m"
+    exit 1
+}
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo_error "Need elevated permissions ... run as root (sudo) ..."
+fi
+
+if [ $# -ne 1 ]; then
+    echo_error "Usage: $0 <image.img.gz>"
+fi
+
+IMAGE_FILE="$1"
+
+if [ ! -f "$IMAGE_FILE" ]; then
+    echo_error "Image file not found: $IMAGE_FILE ..."
+fi
+
+if [[ "$IMAGE_FILE" != *.gz ]]; then
+    echo_error "This script requires a compressed .img.gz file ..."
+fi
+
+for cmd in gunzip dd blkid mount sed; do
+    if ! command -v $cmd &> /dev/null; then
+        echo_error "Required command '$cmd' not found ..."
+    fi
+done
+
+echo_status "Starting partition update process"
+
+CURRENT_ROOT=$(mount | grep ' on / ' | awk '{print $1}')
+echo_debug "Current root: $CURRENT_ROOT"
+
+if [[ $CURRENT_ROOT == *"mmcblk0p5"* ]]; then
+    echo_debug "Currently booted from A partition set (boot p1, root p5)"
+    ACTIVE_SET="A"
+    INACTIVE_BOOT="/dev/mmcblk0p2"
+    INACTIVE_ROOT="/dev/mmcblk0p6"
+    ACTIVE_BOOT="/dev/mmcblk0p1"
+    ACTIVE_ROOT="/dev/mmcblk0p5"
+    HOME_PART="/dev/mmcblk0p7"
+    BOOT_PARTITION=1
+    INACTIVE_BOOT_NUM=2
+    ACTIVE_BOOT_NUM=1
+elif [[ $CURRENT_ROOT == *"mmcblk0p6"* ]]; then
+    echo_debug "Currently booted from B partition set (boot p2, root p6)"
+    ACTIVE_SET="B"
+    INACTIVE_BOOT="/dev/mmcblk0p1"
+    INACTIVE_ROOT="/dev/mmcblk0p5"
+    ACTIVE_BOOT="/dev/mmcblk0p2"
+    ACTIVE_ROOT="/dev/mmcblk0p6"
+    HOME_PART="/dev/mmcblk0p7"
+    BOOT_PARTITION=2
+    INACTIVE_BOOT_NUM=1
+    ACTIVE_BOOT_NUM=2
+else
+    echo_error "Unable to determine current boot partition ...\nCurrent root: $CURRENT_ROOT"
+fi
+
+INACTIVE_SET=$([ "$ACTIVE_SET" == "A" ] && echo "B" || echo "A")
+echo_debug "Updating $INACTIVE_SET partition set"
+echo_debug "Inactive boot: $INACTIVE_BOOT"
+echo_debug "Inactive root: $INACTIVE_ROOT"
+
+INACTIVE_BOOT_PARTUUID=$(blkid -s PARTUUID -o value $INACTIVE_BOOT)
+INACTIVE_ROOT_PARTUUID=$(blkid -s PARTUUID -o value $INACTIVE_ROOT)
+HOME_PARTUUID=$(blkid -s PARTUUID -o value $HOME_PART)
+ACTIVE_ROOT_PARTUUID=$(blkid -s PARTUUID -o value $ACTIVE_ROOT)
+ACTIVE_BOOT_PARTUUID=$(blkid -s PARTUUID -o value $ACTIVE_BOOT)
+
+echo_debug "Inactive boot PARTUUID: $INACTIVE_BOOT_PARTUUID"
+echo_debug "Inactive root PARTUUID: $INACTIVE_ROOT_PARTUUID"
+echo_debug "Active boot PARTUUID: $ACTIVE_BOOT_PARTUUID"
+echo_debug "Active root PARTUUID: $ACTIVE_ROOT_PARTUUID"
+echo_debug "Home PARTUUID: $HOME_PARTUUID"
+
+echo_status "WLAN Pi $INACTIVE_SET partition update"
+echo_debug "Using compressed OS image: $IMAGE_FILE"
+
+TEMP_DIR=$(mktemp -d)
+mkdir -p "$TEMP_DIR/mnt_boot" "$TEMP_DIR/mnt_root"
+
+echo_debug "Analyzing compressed image structure ..."
+gunzip -c "$IMAGE_FILE" | dd bs=512 count=34 of="$TEMP_DIR/mbr.img" 2>/dev/null
+PART_INFO=$(fdisk -l "$TEMP_DIR/mbr.img" 2>/dev/null || echo "Failed to read partition info")
+echo "$PART_INFO"
+
+echo_debug "Defining default partition offsets ..."
+BOOT_START=8192        # Default boot partition start
+ROOT_START=1056768     # Default root partition start
+
+IMAGE_PARTS=$(echo "$PART_INFO" | grep -c -E "mbr.img[0-9]")
+echo_debug "Image has $IMAGE_PARTS partitions"
+
+# Standard OS image has 2 partitions (boot+root)
+if [ "$IMAGE_PARTS" -eq 2 ]; then
+    echo_debug "Detected standard image (non A/B partitioned)"
+
+    BOOT_START_STR=$(echo "$PART_INFO" | grep 'img1' | awk '{print $2}')  # Column 2 is start
+    if [[ -n "$BOOT_START_STR" && "$BOOT_START_STR" =~ ^[0-9]+$ ]]; then
+        BOOT_START=$BOOT_START_STR
+        echo_debug "Found boot partition start: $BOOT_START"
+    else
+        echo_debug "Using default boot start: $BOOT_START"
+    fi
+
+    # Use the size directly from column 4 instead of calculating
+    BOOT_SIZE_STR=$(echo "$PART_INFO" | grep 'img1' | awk '{print $4}')  # Column 4 is sectors
+    if [[ -n "$BOOT_SIZE_STR" && "$BOOT_SIZE_STR" =~ ^[0-9]+$ ]]; then
+        BOOT_SIZE=$BOOT_SIZE_STR
+        echo_debug "Detected boot partition size: $BOOT_SIZE sectors ($(($BOOT_SIZE * 512 / 1024 / 1024)) MB)"
+    else
+        BOOT_SIZE=524288  # 256MB default
+        echo_debug "Using default boot size: $(($BOOT_SIZE * 512 / 1024 / 1024)) MB"
+    fi
+
+    # Extract root partition details from standard image - use the correct columns
+    ROOT_START_STR=$(echo "$PART_INFO" | grep 'img2' | awk '{print $2}')  # Column 2 is start
+    if [[ -n "$ROOT_START_STR" && "$ROOT_START_STR" =~ ^[0-9]+$ ]]; then
+        ROOT_START=$ROOT_START_STR
+        echo_debug "Found root partition start: $ROOT_START"
+    else
+        echo_debug "Using default root start: $ROOT_START"
+    fi
+
+    # Use the size directly from column 4 instead of calculating
+    ROOT_SIZE_STR=$(echo "$PART_INFO" | grep 'img2' | awk '{print $4}')  # Column 4 is sectors
+    if [[ -n "$ROOT_SIZE_STR" && "$ROOT_SIZE_STR" =~ ^[0-9]+$ ]]; then
+        ROOT_SIZE=$ROOT_SIZE_STR
+        echo_debug "Detected root partition size: $ROOT_SIZE sectors ($(($ROOT_SIZE * 512 / 1024 / 1024)) MB)"
+    else
+        ROOT_SIZE=5242880  # 2.5GB default
+        echo_debug "Using default root size: $(($ROOT_SIZE * 512 / 1024 / 1024)) MB"
+    fi
+# A/B partitioned image has at least 3 partitions
+else
+    echo_debug "Detected A/B partitioned image"
+    # Use defaults for A/B partitioned images
+    BOOT_START=2048
+    BOOT_SIZE=524288      # 256MB
+    ROOT_START=532480     # After Boot B
+    ROOT_SIZE=5242880     # 2.5GB
+    echo_debug "Using A/B partition defaults"
+fi
+
+echo_debug "Using boot partition offset: $BOOT_START sectors"
+echo_debug "Using root partition offset: $ROOT_START sectors"
+
+echo_debug "Checking destination partition sizes..."
+
+BOOT_TARGET_SIZE=$(lsblk -b ${INACTIVE_BOOT} -o SIZE -n | tr -d '[:space:]')
+ROOT_TARGET_SIZE=$(lsblk -b ${INACTIVE_ROOT} -o SIZE -n | tr -d '[:space:]')
+
+BOOT_TARGET_SIZE_MB=$((BOOT_TARGET_SIZE / 1024 / 1024))
+ROOT_TARGET_SIZE_MB=$((ROOT_TARGET_SIZE / 1024 / 1024))
+echo_debug "Target boot partition size: ${BOOT_TARGET_SIZE_MB} MB"
+echo_debug "Target root partition size: ${ROOT_TARGET_SIZE_MB} MB"
+
+BOOT_IMAGE_SIZE_BYTES=$((BOOT_SIZE * 512))
+ROOT_IMAGE_SIZE_BYTES=$((ROOT_SIZE * 512))
+BOOT_IMAGE_SIZE_MB=$((BOOT_IMAGE_SIZE_BYTES / 1024 / 1024))
+ROOT_IMAGE_SIZE_MB=$((ROOT_IMAGE_SIZE_BYTES / 1024 / 1024))
+
+echo_debug "Boot image size: ${BOOT_IMAGE_SIZE_MB} MB (${BOOT_SIZE} sectors)"
+echo_debug "Root image size: ${ROOT_IMAGE_SIZE_MB} MB (${ROOT_SIZE} sectors)"
+
+if [ $BOOT_IMAGE_SIZE_BYTES -gt $BOOT_TARGET_SIZE ]; then
+    echo_warning "Boot image (${BOOT_IMAGE_SIZE_MB} MB) is larger than target partition (${BOOT_TARGET_SIZE_MB} MB)"
+    echo_warning "Will copy only what fits in the target partition"
+    BOOT_SIZE=$((BOOT_TARGET_SIZE / 512))
+    echo_debug "Adjusted boot copy size to: $((BOOT_SIZE * 512 / 1024 / 1024)) MB (${BOOT_SIZE} sectors)"
+fi
+
+if [ $ROOT_IMAGE_SIZE_BYTES -gt $ROOT_TARGET_SIZE ]; then
+    echo_warning "Root image (${ROOT_IMAGE_SIZE_MB} MB) is larger than target partition (${ROOT_TARGET_SIZE_MB} MB)"
+    ROOT_SIZE=$((ROOT_TARGET_SIZE / 512))
+    echo_debug "Adjusted root copy size to: $((ROOT_SIZE * 512 / 1024 / 1024)) MB (${ROOT_SIZE} sectors) to prevent truncation"
+fi
+
+echo_debug "Verifying target partitions ..."
+if [[ "$INACTIVE_BOOT" != "/dev/mmcblk0p1" && "$INACTIVE_BOOT" != "/dev/mmcblk0p2" ]]; then
+    echo_error "Invalid boot target: $INACTIVE_BOOT - should be either p1 or p2"
+fi
+
+if [[ "$INACTIVE_ROOT" != "/dev/mmcblk0p5" && "$INACTIVE_ROOT" != "/dev/mmcblk0p6" ]]; then
+    echo_error "Invalid root target: $INACTIVE_ROOT - should be either p5 or p6"
+fi
+
+echo_debug "Confirmed targets: Boot=$INACTIVE_BOOT, Root=$INACTIVE_ROOT"
+
+echo_debug "Streaming boot partition to $INACTIVE_BOOT ..."
+gunzip -c "$IMAGE_FILE" | dd bs=512 skip=$BOOT_START count=$BOOT_SIZE of="$INACTIVE_BOOT" conv=notrunc status=progress
+
+echo_debug "Streaming root partition to $INACTIVE_ROOT ..."
+gunzip -c "$IMAGE_FILE" | dd bs=512 skip=$ROOT_START count=$ROOT_SIZE of="$INACTIVE_ROOT" conv=notrunc status=progress
+
+echo_debug "Mounting updated partitions for configuration ..."
+mount "$INACTIVE_BOOT" "$TEMP_DIR/mnt_boot"
+mount "$INACTIVE_ROOT" "$TEMP_DIR/mnt_root"
+
+if [ -f "$TEMP_DIR/mnt_boot/cmdline.txt" ]; then
+    echo_debug "Found cmdline.txt in image, updating for both A and B partitions ..."
+
+    echo_debug "Original cmdline.txt content:"
+    cat "$TEMP_DIR/mnt_boot/cmdline.txt"
+
+    cp "$TEMP_DIR/mnt_boot/cmdline.txt" "$TEMP_DIR/mnt_boot/cmdline.txt.new"
+    echo_debug "Replacing root PARTUUID with ${INACTIVE_ROOT_PARTUUID} for inactive partition ..."
+    sed -i "s|root=PARTUUID=[^ ]*|root=PARTUUID=${INACTIVE_ROOT_PARTUUID}|" "$TEMP_DIR/mnt_boot/cmdline.txt.new"
+
+    echo_debug "Modified cmdline.txt content:"
+    cat "$TEMP_DIR/mnt_boot/cmdline.txt.new"
+
+    mv "$TEMP_DIR/mnt_boot/cmdline.txt.new" "$TEMP_DIR/mnt_boot/cmdline.txt"
+
+    echo_debug "Creating cmdline-b.txt with active root PARTUUID ${ACTIVE_ROOT_PARTUUID} ..."
+    cp "$TEMP_DIR/mnt_boot/cmdline.txt" "$TEMP_DIR/mnt_boot/cmdline-b.txt"
+    sed -i "s|root=PARTUUID=${INACTIVE_ROOT_PARTUUID}|root=PARTUUID=${ACTIVE_ROOT_PARTUUID}|" "$TEMP_DIR/mnt_boot/cmdline-b.txt"
+else
+    echo_warning "cmdline.txt not found in image. Creating from scratch ..."
+
+    BASE_CMDLINE="console=ttyAMA3,115200 console=tty1 root=PARTUUID=PLACEHOLDER rootfstype=ext4 fsck.repair=yes rootwait"
+
+    echo_debug "Creating cmdline.txt for inactive root partition (PARTUUID=${INACTIVE_ROOT_PARTUUID}) ..."
+    echo "${BASE_CMDLINE/PLACEHOLDER/$INACTIVE_ROOT_PARTUUID}" > "$TEMP_DIR/mnt_boot/cmdline.txt"
+
+    echo_debug "Creating cmdline-b.txt for active root partition (PARTUUID=${ACTIVE_ROOT_PARTUUID}) ..."
+    echo "${BASE_CMDLINE/PLACEHOLDER/$ACTIVE_ROOT_PARTUUID}" > "$TEMP_DIR/mnt_boot/cmdline-b.txt"
+fi
+
+echo_debug "--------------------------------"
+echo_debug "Final cmdline.txt:"
+cat "$TEMP_DIR/mnt_boot/cmdline.txt" | sed 's/^/    /'
+echo_debug "--------------------------------"
+echo_debug "Final cmdline-b.txt:"
+cat "$TEMP_DIR/mnt_boot/cmdline-b.txt" | sed 's/^/    /'
+echo_debug "--------------------------------"
+
+echo_debug "Creating tryboot.txt ..."
+cat > "$TEMP_DIR/mnt_boot/tryboot.txt" << EOF
+# This configuration will be used when booting in tryboot mode
+# Point to the alternate partition
+kernel=wlanpi-kernel8.img
+os_prefix=$ACTIVE_BOOT_NUM:/
+cmdline=cmdline-b.txt
+EOF
+
+echo_debug "Creating autoboot.txt on inactive boot partition ..."
+cat > "$TEMP_DIR/mnt_boot/autoboot.txt" << EOF
+boot_partition=$INACTIVE_BOOT_NUM
+tryboot_a_b=1
+EOF
+
+echo_debug "Updating autoboot.txt on active boot partition ..."
+cat > /boot/autoboot.txt << EOF
+boot_partition=$ACTIVE_BOOT_NUM
+tryboot_a_b=1
+EOF
+
+echo_debug "Updating fstab in inactive root partition ..."
+cat > "$TEMP_DIR/mnt_root/etc/fstab" << EOF
+PARTUUID=${INACTIVE_ROOT_PARTUUID}  /        ext4    defaults,noatime  0  1
+PARTUUID=${INACTIVE_BOOT_PARTUUID}  /boot    vfat    defaults          0  2
+PARTUUID=${HOME_PARTUUID}           /home    ext4    defaults,noatime  0  2
+EOF
+
+echo_debug "Unmounting partitions ..."
+umount "$TEMP_DIR/mnt_boot"
+umount "$TEMP_DIR/mnt_root"
+
+echo_debug "Cleaning up ..."
+rm -rf "$TEMP_DIR"
+
+echo_status "$INACTIVE_SET Partitions Update Complete"
+echo ""
+echo_debug "Next Steps:"
+
+TARGET_BOOT_NUM=$INACTIVE_BOOT_NUM
+TARGET_SET=$INACTIVE_SET
+SOURCE_SET=$ACTIVE_SET
+
+echo "1. Test the updated $TARGET_SET partition set:"
+echo "   sudo reboot '$TARGET_BOOT_NUM tryboot'"
+echo ""
+echo "2. After booting to $TARGET_SET, verify the system is working correctly:"
+echo "   sudo boot-info  # Check boot configuration"
+echo ""
+echo "3. If the $TARGET_SET partition is working as expected and you want to make it permanent:"
+echo "   sudo commit-current-partition"
+echo ""
+echo "4. To return to partition set $SOURCE_SET without making $TARGET_SET permanent:"
+echo "   sudo reboot  # Will return to $SOURCE_SET automatically"
+echo ""


### PR DESCRIPTION
## Type of change 

<!--
Feel free to remove sections and items that don't pertain to the context of your PR.
For example, if you're updating docs, you don't need the testing section.
Note that you do not need to delete these HTML comments as they are not visible after the PR is submitted.
-->

<!-- *Pick at least one.* -->

* [X] Bug fix (non-breaking change that fixes something)
* [ ] Documentation update (readme, changelog, man page, etc.)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature changing existing functionality)
* [X] Code quality improvement (refactor, performance improvements)
* [ ] Other (please specify):

## Breaking change

<!-- *Does this Pull Request introduce a breaking change?* -->

N/A

- What functionality breaks?
- Why does it break?
- How should it be migrated?  
- Are there any backward-compatible alternatives?

## Proposed change

<!-- *Please describe the purpose of this change, the problem it solves, and why the change is necessary. Including code snippets or links to related documentation when applicable will assist approval.* -->

This PR improves the reliability of the UFW configuration during first boot by adding safety checks to prevent accidental system lockouts.

### Changes

- Add verification to ensure SSH port (22/tcp) is allowed before enabling UFW
- Add retry mechanism for SSH rule if it's not properly added the first time
- Prevent UFW enablement if SSH rule cannot be verified, exiting with an error status
- Improve error handling for WiFi country code setting

### Rationale

During first boot, multiple services may configure UFW concurrently, potentially causing race conditions. The most critical issue is ensuring SSH access is maintained before enabling the firewall. This change ensures the system remains accessible by:

1. Verifying SSH rule is properly added
2. Retrying the SSH rule if initial attempt fails
3. Only enabling UFW if SSH access is confirmed
4. Exiting with error status if SSH rule cannot be guaranteed

## Testing

<!-- *Please explain how you tested this change manually, and if applicable, what new tests you added.* -->

- Verified script properly enables ufw when SSH rule is present
- Confirmed script refuses to enable ufw when SSH rule addition fails

## Checklist

<!-- No PR without a related GH issue! Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, homing pigeon, or slack are great starting points, but **do not count** for this requirement. --> 

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [ ] I ran the test suite and verified it succeeded
* [X] I linked a GitHub issue to this PR (in the next section). 
* [ ] I have updated the changelog (if applicable)
* [ ] I have added or updated the documentation (if applicable)

## Related Issues/PRs

<!-- *Pick at least one. Delete the other lines.* -->

- This PR is related to issue #13 