### PR TITLE
Added /etc/home-partition-expanded after resize is completed

### DIFF
--- a/scripts/ab-partition
+++ b/scripts/ab-partition
@@ -492,6 +492,7 @@ mount $HOME_PART /home
 echo "Expansion complete (hopefully!) ..."
 df -h /home
 fdisk -l $DEVICE
+touch /etc/home-partition-expanded
 EOF
 
 chmod +x "$NEW_ROOTFS/usr/local/sbin/expand-home-partition"


### PR DESCRIPTION
## Type of change 
* [X] Bug fix (non-breaking change that fixes something)

## Breaking change
No

## Proposed change
Speeds up boot process by disabling wlanpi-first-boot.service after it runs on first boot

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [X] I ran the test suite and verified it succeeded
* [X] I linked a GitHub issue to this PR (in the next section). 

## Related Issues/PRs
- This PR fixes/closes issue #41 