### PR TITLE
Update partition management scripts to handle configfs partition 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -863,21 +863,34 @@ jobs:
             exit 1
           fi
           
-          sudo mkdir -p /mnt/test_boot
-          sudo mount "${LOOP_DEV}p1" /mnt/test_boot
-          
-          BOOT_FILES=("cmdline.txt" "config.txt" "autoboot.txt" "tryboot.txt")
-          for file in "${BOOT_FILES[@]}"; do
-            if [ ! -f "/mnt/test_boot/$file" ]; then
-              echo "Error: missing boot file: $file"
-              sudo umount /mnt/test_boot
+          sudo mkdir -p /mnt/test_boot1 /mnt/test_boot2
+          sudo mount "${LOOP_DEV}p2" /mnt/test_boot2
+          sudo mount "${LOOP_DEV}p1" /mnt/test_boot1
+          CONFIG_FILES=("autoboot.txt" "tryboot.txt")
+          for file in "${CONFIG_FILES[@]}"; do
+            if [ ! -f "/mnt/test_boot1/$file" ]; then
+              echo "Error: missing config file on CONFIGFS partition 1: $file"
+              sudo umount /mnt/test_boot1
+              sudo umount /mnt/test_boot2
               sudo losetup -d "$LOOP_DEV"
               rm "$TEMP_IMG"
               exit 1
             fi
           done
-          
-          sudo umount /mnt/test_boot
+          BOOT2_FILES=("cmdline.txt" "config.txt")
+          for file in "${BOOT2_FILES[@]}"; do
+            if [ ! -f "/mnt/test_boot2/$file" ]; then
+              echo "Error: missing boot file on BOOT1FS partition 2: $file"
+              sudo umount /mnt/test_boot1
+              sudo umount /mnt/test_boot2
+              sudo losetup -d "$LOOP_DEV"
+              rm "$TEMP_IMG"
+              exit 1
+            fi
+          done
+          sudo umount /mnt/test_boot1
+          sudo umount /mnt/test_boot2
+
           sudo losetup -d "$LOOP_DEV"
           rm "$TEMP_IMG"
           

--- a/README.md
+++ b/README.md
@@ -11,9 +11,19 @@ Tool based on pi-gen to generate WLAN Pi OS images for bookworm.
 
 - `boot-info`: diagnostic information about current boot/root partitions
 - `update-alternate-partition`: updates the inactive partition
-- `tryboot-alternative`: ensures tryboot is setup properly 
+- `tryboot-alternate`: ensures tryboot is setup properly 
 - `commit-current-partition`: makes autoboot.txt point towards booted partition confirming verification
 
 Manual trigger tryboot:
 
-- `sudo reboot 'N tryboot'`: tests booting to the updated partition safely. Use 1 or 2.
+- `sudo reboot '0 tryboot'`: tests booting to the updated partition safely using CONFIGFS configuration.
+
+## Partition structure
+
+The A/B partition layout uses:
+- `p1`: CONFIGFS partition containing autoboot.txt and tryboot.txt
+- `p2/p5`: Partition set A (boot/root)
+- `p3/p6`: Partition set B (boot/root)
+- `p7`: Home partition (shared)
+
+Boot configuration is controlled by autoboot.txt in the CONFIGFS partition (p1), which determines which partition set boots by default.

--- a/README.md
+++ b/README.md
@@ -7,17 +7,31 @@ Tool based on pi-gen to generate WLAN Pi OS images for bookworm.
 - [DOCS](docs/PRDs.md)
 - [README](PI-GEN.md)
 
-## Lite image update tools
+## A/B partition management tools
 
-- `boot-info`: diagnostic information about current boot/root partitions
-- `update-alternate-partition`: updates the inactive partition
-- `tryboot-alternate`: ensures tryboot is setup properly 
-- `commit-current-partition`: makes autoboot.txt point towards booted partition confirming verification
+- `boot-info`: Shows current partition set, CONFIGFS configuration, and boot history
+- `update-alternate-partition <image.img.gz>`: Updates the inactive partition set from compressed OS image
+- `tryboot-alternate`: Configures CONFIGFS tryboot.txt for testing the alternate partition set
+- `commit-current-partition`: Updates CONFIGFS autoboot.txt to make current partition set the default
 
 Manual trigger tryboot:
 
 - `sudo reboot '2 tryboot'`: tests booting to partition set A (boot p2, root p5)
 - `sudo reboot '3 tryboot'`: tests booting to partition set B (boot p3, root p6)
+
+Notes:
+
+- Tryboot tests are temporary - failed boots automatically revert to the original partition
+- The home partition (p7) is shared between both partition sets
+- CONFIGFS autoboot.txt controls default boot behavior after power loss
+
+## Typical A/B update workflow
+
+1. Update the inactive partition: `sudo update-alternate-partition <image.img.gz>`
+2. Configure tryboot: `sudo tryboot-alternate` 
+3. Test the update: Use the reboot command displayed by `tryboot-alternate`
+4. Verify functionality: `sudo boot-info`
+5. Make permanent: `sudo commit-current-partition`
 
 ## Partition structure
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Tool based on pi-gen to generate WLAN Pi OS images for bookworm.
 
 Manual trigger tryboot:
 
-- `sudo reboot '0 tryboot'`: tests booting to the updated partition safely using CONFIGFS configuration.
+- `sudo reboot '2 tryboot'`: tests booting to partition set A (boot p2, root p5)
+- `sudo reboot '3 tryboot'`: tests booting to partition set B (boot p3, root p6)
 
 ## Partition structure
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ Tool based on pi-gen to generate WLAN Pi OS images for bookworm.
 
 ## A/B partition management tools
 
-- `boot-info`: Shows current partition set, CONFIGFS configuration, and boot history
-- `update-alternate-partition <image.img.gz>`: Updates the inactive partition set from compressed OS image
-- `tryboot-alternate`: Configures CONFIGFS tryboot.txt for testing the alternate partition set
-- `commit-current-partition`: Updates CONFIGFS autoboot.txt to make current partition set the default
+0. `boot-info`: Shows current partition set, CONFIGFS configuration, and boot history
+0. `update-alternate-partition <image.img.gz>`: Updates the inactive partition set from compressed OS image
+0. `tryboot-alternate`: Configures CONFIGFS tryboot.txt for testing the alternate partition set
+0. `commit-current-partition`: Updates CONFIGFS autoboot.txt to make current partition set the default
 
 Manual trigger tryboot:
 
-- `sudo reboot '2 tryboot'`: tests booting to partition set A (boot p2, root p5)
-- `sudo reboot '3 tryboot'`: tests booting to partition set B (boot p3, root p6)
+- `sudo reboot '2 tryboot'`: reboots and tests booting to partition set **A** (boot p2, root p5)
+- `sudo reboot '3 tryboot'`: reboots and tests booting to partition set **B** (boot p3, root p6)
 
 Notes:
 
@@ -25,13 +25,20 @@ Notes:
 - The home partition (p7) is shared between both partition sets
 - CONFIGFS autoboot.txt controls default boot behavior after power loss
 
+## `tryboot-alternate` usage
+
+- `sudo tryboot-alternate --check`: See what would happen without applying changes
+- `sudo tryboot-alternate`: Apply tryboot configuration and immediately reboot to test alternate partition
+- After successful test: `sudo commit-current-partition`
+
 ## Typical A/B update workflow
 
-1. Update the inactive partition: `sudo update-alternate-partition <image.img.gz>`
-2. Configure tryboot: `sudo tryboot-alternate` 
-3. Test the update: Use the reboot command displayed by `tryboot-alternate`
-4. Verify functionality: `sudo boot-info`
-5. Make permanent: `sudo commit-current-partition`
+0. Update the inactive partition: `sudo update-alternate-partition <image.img.gz>`
+0. Test the update: `sudo tryboot-alternate` 
+0. Verify functionality: `sudo boot-info`
+0. Make permanent: `sudo commit-current-partition`
+
+You can also verify the update was applied by checking the traceability information in `/etc/rpi-issue`.
 
 ## Partition structure
 

--- a/scripts/ab-partition
+++ b/scripts/ab-partition
@@ -469,14 +469,14 @@ echo "Starting home partition expansion ..."
 
 DEVICE=$(findmnt -n -o SOURCE /home | sed 's/p[0-9]\+$//')
 HOME_PART=$(findmnt -n -o SOURCE /home)
-EXTENDED_PART="${DEVICE}p3"
+EXTENDED_PART="${DEVICE}p4"
 TOTAL_SECTORS=$(fdisk -l $DEVICE | grep "sectors$" | awk '{print $7}')
 
 echo "Unmounting home partition ..."
 umount /home
 
 echo "Resizing extended partition to fill disk ..."
-parted -s $DEVICE unit s resizepart 3 $((TOTAL_SECTORS - 2048))
+parted -s $DEVICE unit s resizepart 4 $((TOTAL_SECTORS - 2048))
 
 echo "Updating partition table ..."
 partprobe $DEVICE

--- a/scripts/ab-partition
+++ b/scripts/ab-partition
@@ -100,6 +100,7 @@ echo "Temp directory: $TEMP_DIR"
 ORIGINAL_SIZE=$(stat -c%s "$INPUT_IMAGE")
 echo "Original image size: $(( ORIGINAL_SIZE / 1024 / 1024 )) MB"
 
+CONFIGFS_SIZE=$((16 * 1024 * 1024))         # 16 MB
 BOOT1_SIZE=$((256 * 1024 * 1024))           # 256 MB
 BOOT2_SIZE="${BOOT1_SIZE}"
 ROOT1_SIZE=$((ROOT_SIZE_MB * 1024 * 1024))  # MB to bytes
@@ -109,6 +110,7 @@ BUFFER_SIZE=$((32 * 1024 * 1024))           # 32 MB
 ALIGN=$((1024 * 1024))
 
 NEW_SIZE=$ALIGN
+NEW_SIZE=$((NEW_SIZE + CONFIGFS_SIZE))
 NEW_SIZE=$((NEW_SIZE + BOOT1_SIZE))
 NEW_SIZE=$((NEW_SIZE + BOOT2_SIZE))
 NEW_SIZE=$((NEW_SIZE + ROOT1_SIZE))
@@ -180,7 +182,13 @@ echo "Calculating partition positions ..."
 SECTOR_SIZE=512 # Define in sectors (512 bytes each)
 SECTORS_PER_MB=$((1024*1024 / SECTOR_SIZE))  # 2048 sectors per MB
 
-p1_start=$((SECTORS_PER_MB * 1))  # Start at 1MB
+config_start=$((SECTORS_PER_MB * 1))  # Start at 1MB
+config_size=$((CONFIGFS_SIZE / SECTOR_SIZE))
+config_end=$((config_start + config_size - 1))
+
+
+p1_start=$((config_end + 1))
+p1_start=$(((p1_start + SECTORS_PER_MB - 1) / SECTORS_PER_MB * SECTORS_PER_MB))  # Align to MB
 p1_size=$((BOOT1_SIZE / SECTOR_SIZE))
 p1_end=$((p1_start + p1_size - 1))
 
@@ -237,6 +245,7 @@ fi
 
 echo "Running parted ..."
 parted --script "$OUTPUT_IMAGE" mklabel msdos
+parted --script "$OUTPUT_IMAGE" unit s mkpart primary fat16 ${config_start} ${config_end} # Config FS
 parted --script "$OUTPUT_IMAGE" unit s mkpart primary fat32 ${p1_start} ${p1_end} # Primary boot A
 parted --script "$OUTPUT_IMAGE" unit s mkpart primary fat32 ${p2_start} ${p2_end} # Primary boot B
 parted --script "$OUTPUT_IMAGE" unit s mkpart extended ${p3_start} ${LAST_SECTOR}
@@ -269,23 +278,24 @@ fi
 
 echo "Giving the system three seconds to stabilize ..."
 sleep 3
-
-BOOT1_DEV="${NEW_LOOP_DEV}p1"
-BOOT2_DEV="${NEW_LOOP_DEV}p2"
-# p3 is the extended container; skipping.
+CONFIG_DEV="${NEW_LOOP_DEV}p1"
+BOOT1_DEV="${NEW_LOOP_DEV}p2"
+BOOT2_DEV="${NEW_LOOP_DEV}p3"
+# p4 is the extended container; skipping.
 ROOT1_DEV="${NEW_LOOP_DEV}p5"
 ROOT2_DEV="${NEW_LOOP_DEV}p6"
 PERSISTENT_DEV="${NEW_LOOP_DEV}p7" # /home is last partition so we can resize it to fill fs
 
 echo "Formatting partitions ..."
-if [ "$BOOT1_SIZE" -lt 134742016 ]; then
+CONFIG_SIZE=$(blockdev --getsize64 "$CONFIG_DEV")
+if [ "$CONFIG_DEV" -lt 134742016 ]; then
     FAT_SIZE=16
     echo "Fat size set to 16 ..."
 else
     FAT_SIZE=32
     echo "Fat size set to 32 ..."
 fi
-
+mkfs.vfat -F "$FAT_SIZE" -n CONFIGFS "${CONFIG_DEV}"
 mkfs.vfat -F "$FAT_SIZE" -n BOOT1FS "${BOOT1_DEV}"
 mkfs.vfat -F "$FAT_SIZE" -n BOOT2FS "${BOOT2_DEV}"
 mkfs.ext4 -F -L ROOT1FS "${ROOT1_DEV}" -O ^huge_file
@@ -306,29 +316,6 @@ for file in bootcode.bin start.elf fixup.dat; do
     fi
 done
 
-echo "Creating failback config.txt on boot B ..."
-cat > "$BOOT2_MNT/config.txt" << EOF
-# Minimal config.txt for failback mechanism to boot A
-# Boot B partition is not fully provisioned yet
-[tryboot]
-boot_partition=1
-EOF
-
-echo "Creating failback tryboot.txt on boot B ..."
-cat > "$BOOT2_MNT/tryboot.txt" << EOF
-# FAILBACK CONFIGURATION
-# Immediately points back to A partitions if tryboot is used
-# Safety mechanism for when partition B is not fully provisioned
-kernel=wlanpi-kernel8.img
-os_prefix=1:/
-EOF
-
-sync
-umount "$BOOT2_MNT"
-rmdir "$BOOT2_MNT"
-
-echo "Minimal failback setup on Boot B partition completed ..."
-
 echo "Getting partition UUIDs ..."
 BOOT1_PARTUUID=$(blkid -s PARTUUID -o value "${BOOT1_DEV}")
 BOOT2_PARTUUID=$(blkid -s PARTUUID -o value "${BOOT2_DEV}")
@@ -345,6 +332,28 @@ echo "Re-mounting original image to copy content ..."
 ORIG_LOOP_DEV=$(losetup --show -P -f "$INPUT_IMAGE")
 mount "${ORIG_LOOP_DEV}"p1 "$ORIGINAL_BOOT"
 mount "${ORIG_LOOP_DEV}"p2 "$ORIGINAL_ROOT"
+
+echo "Setting up A/B boot configuration on config partition ..."
+CONFIG_MNT="$TEMP_DIR/config_mnt"
+mkdir -p "$CONFIG_MNT"
+mount -v "${CONFIG_DEV}" "${CONFIG_MNT}" -t vfat
+
+cat > "$CONFIG_MNT/autoboot.txt" << EOF
+boot_partition=2
+tryboot_a_b=1
+EOF
+
+cat > "$CONFIG_MNT/tryboot.txt" << EOF
+# This configuration will be used when booting in tryboot mode
+# Point to the B partitions
+kernel=wlanpi-kernel8.img
+os_prefix=3:/
+cmdline=cmdline-b.txt
+EOF
+
+sync
+umount "$CONFIG_MNT"
+rmdir "$CONFIG_MNT"
 
 echo "Mounting new partitions ..."
 mount -v "${ROOT1_DEV}" "${NEW_ROOTFS}" -t ext4
@@ -436,20 +445,6 @@ if [ ! -d "$NEW_ROOTFS/boot/overlays" ] && [ -d "$ORIGINAL_BOOT/overlays" ]; the
     cp -a "$ORIGINAL_BOOT/overlays/"* "$NEW_ROOTFS/boot/overlays/"
     echo "Ensured overlays directory exists with proper content ..."
 fi
-
-echo "Setting up A/B boot configuration ..."
-cat > "$NEW_ROOTFS/boot/autoboot.txt" << EOF
-boot_partition=1
-tryboot_a_b=1
-EOF
-
-cat > "$NEW_ROOTFS/boot/tryboot.txt" << EOF
-# This configuration will be used when booting in tryboot mode
-# Point to the B partitions
-kernel=wlanpi-kernel8.img
-os_prefix=2:/
-cmdline=cmdline-b.txt
-EOF
 
 echo "Updating fstab for new partition layout ..."
 cat > "$NEW_ROOTFS/etc/fstab" << EOF

--- a/scripts/ab-partition
+++ b/scripts/ab-partition
@@ -584,14 +584,15 @@ echo
 echo "Verify integrity with: sha256sum --check ""$OUTPUT_IMAGE"".sha256"
 echo
 echo "The image has the following partition structure:"
-echo "1: BOOT1FS   - Primary boot partition (A)"
-echo "2: BOOT2FS  - Primary boot partition (B)"
-echo "3: Extended partition container for additional logical partitions"
+echo "1: CONFIGFS  - Configuration partition for A/B boot management"
+echo "2: BOOT1FS   - Primary boot partition (A)"
+echo "3: BOOT2FS   - Primary boot partition (B)"
+echo "4: Extended partition container for additional logical partitions"
 echo "  - 5: ROOT1FS   - Root partition (A)"
 echo "  - 6: ROOT2FS  - Root partition (B)"
 echo "  - 7: HOME     - Persistent partition (automatically expanded on first boot)"
 echo
-echo "Partition structure is optimized for CM4s with 8 GB of disk"
+echo "Partition structure is by default optimized for CM4s with 8 GB of disk"
 echo "====================================="
 echo
 echo "ab-partition finished ..."

--- a/scripts/ab-partition
+++ b/scripts/ab-partition
@@ -460,49 +460,195 @@ cat > "$NEW_ROOTFS/usr/local/sbin/expand-home-partition" << 'EOF'
 
 # First boot script to expand the home partition 
 
-if [ -f /etc/home-partition-expanded ]; then
-    echo "Home partition already expanded ... exiting..."
+set -euo pipefail  # Exit on any error, undefined variables, or pipe failures
+
+LOG_FILE="/var/log/expand-home-partition.log"
+LOCK_FILE="/var/lock/expand-home-partition.lock"
+EXPANDED_MARKER="/etc/home-partition-expanded"
+mkdir -p "$(dirname "$LOG_FILE")" "$(dirname "$LOCK_FILE")"
+
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" | tee -a "$LOG_FILE"
+}
+
+cleanup() {
+    local exit_code=$?
+    if [[ -f "$LOCK_FILE" ]]; then
+        rm -f "$LOCK_FILE"
+    fi
+    
+    if ! mountpoint -q /home 2>/dev/null; then
+        log "Emergency: Attempting to remount /home"
+        # Try to determine HOME_PART if not set
+        local home_part="${HOME_PART:-$(findmnt -n -o SOURCE /home 2>/dev/null || echo '')}"
+        if [[ -n "$home_part" ]]; then
+            mount "$home_part" /home 2>/dev/null || log "ERROR: Failed to remount /home"
+        else
+            log "ERROR: Could not determine home partition for emergency remount"
+        fi
+    fi
+    
+    exit $exit_code
+}
+
+trap cleanup EXIT INT TERM
+
+if [[ -f "$EXPANDED_MARKER" ]]; then
+    log "Home partition already expanded ... exiting..."
     exit 0
 fi
 
-echo "Starting home partition expansion ..."
+if [[ -f "$LOCK_FILE" ]]; then
+    log "Another expansion process is running, exiting"
+    exit 1
+fi
+touch "$LOCK_FILE"
 
-DEVICE=$(findmnt -n -o SOURCE /home | sed 's/p[0-9]\+$//')
-HOME_PART=$(findmnt -n -o SOURCE /home)
+log "Starting home partition expansion"
+
+
+DEVICE=$(findmnt -n -o SOURCE /home | sed 's/p[0-9]\+$//' 2>/dev/null)
+HOME_PART=$(findmnt -n -o SOURCE /home 2>/dev/null)
+
+if [[ -z "$DEVICE" || -z "$HOME_PART" ]]; then
+    log "ERROR: Could not determine device or home partition"
+    exit 1
+fi
+
+if [[ ! -b "$DEVICE" || ! -b "$HOME_PART" ]]; then
+    log "ERROR: Device or partition does not exist"
+    exit 1
+fi
+
 EXTENDED_PART="${DEVICE}p4"
-TOTAL_SECTORS=$(fdisk -l $DEVICE | grep "sectors$" | awk '{print $7}')
+log "Device: $DEVICE, Home partition: $HOME_PART, Extended: $EXTENDED_PART"
 
-echo "Unmounting home partition ..."
-umount /home
+TOTAL_SECTORS=$(fdisk -l "$DEVICE" 2>/dev/null | grep "sectors$" | awk '{print $7}')
+if [[ -z "$TOTAL_SECTORS" || ! "$TOTAL_SECTORS" =~ ^[0-9]+$ ]]; then
+    log "ERROR: Could not determine total sectors"
+    exit 1
+fi
 
-echo "Resizing extended partition to fill disk ..."
-parted -s $DEVICE unit s resizepart 4 $((TOTAL_SECTORS - 2048))
+log "Total sectors: $TOTAL_SECTORS"
 
-echo "Updating partition table ..."
-partprobe $DEVICE
-sleep 2
+# Backup current partition table
+log "Backing up partition table"
+sfdisk -d "$DEVICE" > "/tmp/partition-backup-$(date +%s).sfdisk" || {
+    log "WARNING: Could not backup partition table"
+}
 
-echo "Expanding home partition to fill extended partition..."
-EXTENDED_END=$(fdisk -l $DEVICE | grep "$(basename $EXTENDED_PART)" | awk '{print $3}')
-echo "Extended partition now ends at: $EXTENDED_END"
+log "Unmounting home partition"
+sync
 
-parted -s $DEVICE unit s resizepart 7 $((EXTENDED_END - 2048))
+for attempt in {1..3}; do
+    if umount /home 2>/dev/null; then
+        log "Successfully unmounted /home on attempt $attempt"
+        break
+    elif [[ $attempt -eq 3 ]]; then
+        log "ERROR: Failed to unmount /home after 3 attempts"
+        exit 1
+    else
+        log "Unmount attempt $attempt failed, retrying in 2 seconds"
+        sleep 2
+    fi
+done
 
-echo "Updating partition table (again) ..."
-partprobe $DEVICE
-sleep 2
+log "Checking filesystem before expansion"
+if ! timeout 30 e2fsck -f "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"; then
+    log "ERROR: Filesystem check failed or timed out, attempting repair"
+    if ! e2fsck -fy "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"; then
+        log "ERROR: Filesystem repair failed"
+        mount "$HOME_PART" /home
+        exit 1
+    fi
+    log "Filesystem repaired successfully"
+fi
 
-echo "Checking and resizing filesystem ..."
-e2fsck -fy $HOME_PART
-resize2fs $HOME_PART
+log "Resizing extended partition to fill disk"
+if ! parted -s "$DEVICE" unit s resizepart 4 $((TOTAL_SECTORS - 2048)) 2>&1 | tee -a "$LOG_FILE"; then
+    log "ERROR: Failed to resize extended partition"
+    mount "$HOME_PART" /home
+    exit 1
+fi
 
-echo "Remounting home partition ..."
-mount $HOME_PART /home
+log "Updating partition table"
+for attempt in {1..3}; do
+    partprobe "$DEVICE" 2>/dev/null && sleep 2 && break
+    log "Partition table update attempt $attempt failed, retrying"
+    sleep 3
+    if [[ $attempt -eq 3 ]]; then
+        log "ERROR: Failed to update partition table after 3 attempts"
+        mount "$HOME_PART" /home
+        exit 1
+    fi
+done
 
-echo "Expansion complete (hopefully!) ..."
-df -h /home
-fdisk -l $DEVICE
-touch /etc/home-partition-expanded
+EXTENDED_END=$(fdisk -l "$DEVICE" 2>/dev/null | grep "$(basename "$EXTENDED_PART")" | awk '{print $3}')
+if [[ -z "$EXTENDED_END" || ! "$EXTENDED_END" =~ ^[0-9]+$ ]]; then
+    log "ERROR: Could not determine extended partition end"
+    mount "$HOME_PART" /home
+    exit 1
+fi
+
+log "Extended partition ends at sector: $EXTENDED_END"
+
+log "Expanding home partition to fill extended partition"
+if ! parted -s "$DEVICE" unit s resizepart 7 $((EXTENDED_END - 2048)) 2>&1 | tee -a "$LOG_FILE"; then
+    log "ERROR: Failed to resize home partition"
+    mount "$HOME_PART" /home
+    exit 1
+fi
+
+log "Updating partition table (final)"
+for attempt in {1..3}; do
+    partprobe "$DEVICE" 2>/dev/null && sleep 2 && break
+    log "Partition table update attempt $attempt failed, retrying"
+    sleep 3
+    if [[ $attempt -eq 3 ]]; then
+        log "ERROR: Failed to update final partition table after 3 attempts"
+        mount "$HOME_PART" /home
+        exit 1
+    fi
+done
+
+log "Final filesystem check before resize"
+if ! timeout 30 e2fsck -f "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"; then
+    log "WARNING: Filesystem check failed or timed out, attempting repair"
+    if ! e2fsck -fy "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"; then
+        log "ERROR: Critical filesystem repair failed, manual intervention required"
+        mount "$HOME_PART" /home
+        exit 1
+    fi
+fi
+
+log "Resizing filesystem"
+if ! timeout 30 resize2fs "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"; then
+    log "ERROR: Filesystem resize failed - checking if partial resize occurred"
+    if mount "$HOME_PART" /home 2>/dev/null; then
+        CURRENT_SIZE=$(df -BG /home | tail -1 | awk '{print $2}' | sed 's/G//')
+        log "Current filesystem size after failed resize: ${CURRENT_SIZE}GB"
+    fi
+    exit 1
+fi
+
+log "Remounting home partition"
+if ! mount "$HOME_PART" /home; then
+    log "ERROR: Failed to remount /home"
+    exit 1
+fi
+
+HOME_SIZE=$(df -BG /home | tail -1 | awk '{print $2}' | sed 's/G//')
+HOME_SIZE_INT=${HOME_SIZE%.*}
+if [[ "$HOME_SIZE_INT" -lt 8 ]]; then  # Expect at least 8GB
+    log "WARNING: Home partition size ($HOME_SIZE GB) seems smaller than expected"
+else
+    log "SUCCESS: Home partition expanded to ${HOME_SIZE}GB"
+fi
+
+touch "$EXPANDED_MARKER"
+log "Expansion process completed successfully"
+
+df -h /home | tee -a "$LOG_FILE"
 EOF
 
 chmod +x "$NEW_ROOTFS/usr/local/sbin/expand-home-partition"

--- a/scripts/ab-partition
+++ b/scripts/ab-partition
@@ -105,7 +105,7 @@ BOOT1_SIZE=$((256 * 1024 * 1024))           # 256 MB
 BOOT2_SIZE="${BOOT1_SIZE}"
 ROOT1_SIZE=$((ROOT_SIZE_MB * 1024 * 1024))  # MB to bytes
 ROOT2_SIZE="${ROOT1_SIZE}"
-PERSISTENT_MIN_SIZE=$((8 * 1024 * 1024))    # 8 MB
+PERSISTENT_MIN_SIZE=$((512 * 1024 * 1024))    # 512 MB
 BUFFER_SIZE=$((32 * 1024 * 1024))           # 32 MB
 ALIGN=$((1024 * 1024))
 
@@ -300,7 +300,7 @@ mkfs.vfat -F "$FAT_SIZE" -n BOOT1FS "${BOOT1_DEV}"
 mkfs.vfat -F "$FAT_SIZE" -n BOOT2FS "${BOOT2_DEV}"
 mkfs.ext4 -F -L ROOT1FS "${ROOT1_DEV}" -O ^huge_file
 mkfs.ext4 -F -L ROOT2FS "${ROOT2_DEV}" -O ^huge_file
-mkfs.ext4 -F -L HOME "${PERSISTENT_DEV}" -O ^huge_file
+mkfs.ext4 -F -L HOME "${PERSISTENT_DEV}"
 
 echo "Setting up minimal failback on boot B partition ..."
 BOOT2_MNT="$TEMP_DIR/boot2_mnt"
@@ -458,7 +458,7 @@ mkdir -p "$NEW_ROOTFS/usr/local/sbin"
 cat > "$NEW_ROOTFS/usr/local/sbin/expand-home-partition" << 'EOF'
 #!/bin/bash
 
-# First boot script to expand the home partition 
+# First boot script to expand the home partition
 
 set -euo pipefail  # Exit on any error, undefined variables, or pipe failures
 
@@ -476,7 +476,7 @@ cleanup() {
     if [[ -f "$LOCK_FILE" ]]; then
         rm -f "$LOCK_FILE"
     fi
-    
+
     if ! mountpoint -q /home 2>/dev/null; then
         log "Emergency: Attempting to remount /home"
         # Try to determine HOME_PART if not set
@@ -487,7 +487,7 @@ cleanup() {
             log "ERROR: Could not determine home partition for emergency remount"
         fi
     fi
-    
+
     exit $exit_code
 }
 
@@ -556,12 +556,15 @@ done
 log "Checking filesystem before expansion"
 if ! timeout 30 e2fsck -f "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"; then
     log "ERROR: Filesystem check failed or timed out, attempting repair"
-    if ! e2fsck -fy "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"; then
-        log "ERROR: Filesystem repair failed"
+    e2fsck -fy "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"
+    repair_exit_code=$?
+    if [[ $repair_exit_code -eq 0 || $repair_exit_code -eq 1 ]]; then
+        log "Filesystem repaired successfully"
+    else
+        log "ERROR: Critical filesystem repair failed with exit code $repair_exit_code, manual intervention required"
         mount "$HOME_PART" /home
         exit 1
     fi
-    log "Filesystem repaired successfully"
 fi
 
 log "Resizing extended partition to fill disk"
@@ -614,21 +617,63 @@ done
 log "Final filesystem check before resize"
 if ! timeout 30 e2fsck -f "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"; then
     log "WARNING: Filesystem check failed or timed out, attempting repair"
-    if ! e2fsck -fy "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"; then
-        log "ERROR: Critical filesystem repair failed, manual intervention required"
+    e2fsck -fy "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"
+    repair_exit_code=$?
+    if [[ $repair_exit_code -eq 0 || $repair_exit_code -eq 1 ]]; then
+        log "Filesystem repaired successfully"
+    else
+        log "ERROR: Critical filesystem repair failed with exit code $repair_exit_code, manual intervention required"
         mount "$HOME_PART" /home
         exit 1
     fi
+    log "Verifying final filesystem repair"
+    if ! e2fsck -f "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"; then
+        log "WARNING: Filesystem still has issues, running final force repair"
+        e2fsck -fy "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"
+        repair_exit_code=$?
+        if [[ $repair_exit_code -ne 0 && $repair_exit_code -ne 1 ]]; then
+            log "ERROR: Final force repair failed with exit code $repair_exit_code"
+            mount "$HOME_PART" /home
+            exit 1
+        fi
+    fi
 fi
 
-log "Resizing filesystem"
-if ! timeout 30 resize2fs "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"; then
-    log "ERROR: Filesystem resize failed - checking if partial resize occurred"
-    if mount "$HOME_PART" /home 2>/dev/null; then
-        CURRENT_SIZE=$(df -BG /home | tail -1 | awk '{print $2}' | sed 's/G//')
-        log "Current filesystem size after failed resize: ${CURRENT_SIZE}GB"
-    fi
+log "Running final aggressive filesystem repair before resize"
+e2fsck -fy "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"
+repair_exit_code=$?
+if [[ $repair_exit_code -ne 0 && $repair_exit_code -ne 1 ]]; then
+    log "ERROR: Final aggressive repair failed with exit code $repair_exit_code"
+    mount "$HOME_PART" /home
     exit 1
+fi
+# Try resize with error handling for corruption
+if ! timeout 30 resize2fs "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"; then
+    log "ERROR: Filesystem resize failed, attempting corruption recovery"
+
+    # If resize fails due to corruption, try one more repair cycle
+    log "Running emergency filesystem repair"
+    e2fsck -fy "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"
+    repair_exit_code=$?
+    if [[ $repair_exit_code -eq 0 || $repair_exit_code -eq 1 ]]; then
+        log "Emergency filesystem repair completed"
+    else
+        log "ERROR: Emergency filesystem repair failed with exit code $repair_exit_code"
+        mount "$HOME_PART" /home
+        exit 1
+    fi
+
+    # Try resize one more time
+    log "Retrying filesystem resize after repair"
+    if ! timeout 60 resize2fs "$HOME_PART" 2>&1 | tee -a "$LOG_FILE"; then
+        log "ERROR: Filesystem resize failed after repair - checking if partial resize occurred"
+        if mount "$HOME_PART" /home 2>/dev/null; then
+            CURRENT_SIZE=$(df -BG /home | tail -1 | awk '{print $2}' | sed 's/G//')
+            log "Current filesystem size after failed resize: ${CURRENT_SIZE}GB"
+        fi
+        exit 1
+    fi
+    log "Filesystem resize succeeded after repair"
 fi
 
 log "Remounting home partition"

--- a/scripts/ab-partition
+++ b/scripts/ab-partition
@@ -247,9 +247,9 @@ echo "Running parted ..."
 parted --script "$OUTPUT_IMAGE" mklabel msdos
 parted --script "$OUTPUT_IMAGE" unit s mkpart primary fat16 ${config_start} ${config_end} # Config FS
 parted --script "$OUTPUT_IMAGE" unit s mkpart primary fat32 ${p1_start} ${p1_end} # Primary boot A
+parted --script "$OUTPUT_IMAGE" set 2 boot on
 parted --script "$OUTPUT_IMAGE" unit s mkpart primary fat32 ${p2_start} ${p2_end} # Primary boot B
 parted --script "$OUTPUT_IMAGE" unit s mkpart extended ${p3_start} ${LAST_SECTOR}
-parted --script "$OUTPUT_IMAGE" set 1 boot on
 
 parted --script "$OUTPUT_IMAGE" unit s mkpart logical ext4 ${lp1_start} ${lp1_end} # Root A
 parted --script "$OUTPUT_IMAGE" unit s mkpart logical ext4 ${lp2_start} ${lp2_end} # Root B
@@ -288,7 +288,7 @@ PERSISTENT_DEV="${NEW_LOOP_DEV}p7" # /home is last partition so we can resize it
 
 echo "Formatting partitions ..."
 CONFIG_SIZE=$(blockdev --getsize64 "$CONFIG_DEV")
-if [ "$CONFIG_DEV" -lt 134742016 ]; then
+if [ "$CONFIG_SIZE" -lt 134742016 ]; then
     FAT_SIZE=16
     echo "Fat size set to 16 ..."
 else

--- a/wlanpi1-lite/19-ab-scripts/files/boot-info
+++ b/wlanpi1-lite/19-ab-scripts/files/boot-info
@@ -4,7 +4,7 @@
 # A/B partition boot debug script
 # This script provides detailed information about the current boot state
 #
-# Version: v0.1
+# Version: v0.2
 # Author: Josh Schmelzle
 # License: BSD-3
 
@@ -46,32 +46,40 @@ else
     echo "    [File /etc/rpi-issue does not exist]"
 fi
 
+# $ lsblk -o LABEL,NAME,SIZE,MOUNTPOINTS,TYPE
+# LABEL    NAME          SIZE MOUNTPOINTS   TYPE
+#          mmcblk0      14.6G               disk
+# CONFIGFS ├─mmcblk0p1    16M /tmp/configfs part
+# BOOT1FS  ├─mmcblk0p2   256M /boot         part
+# BOOT2FS  ├─mmcblk0p3   256M               part
+#          ├─mmcblk0p4     1K               part
+# ROOT1FS  ├─mmcblk0p5   2.4G /             part
+# ROOT2FS  ├─mmcblk0p6   2.4G               part
+# HOME     └─mmcblk0p7   9.2G /home         part
+#          mmcblk0boot0    4M               disk
+#          mmcblk0boot1    4M               disk
+
 echo_debug "Current partition set analysis:"
 CURRENT_BOOT_DEV=$(findmnt -n -o SOURCE /boot)
 CURRENT_ROOT_DEV=$(findmnt -n -o SOURCE /)
 CURRENT_HOME_DEV=$(findmnt -n -o SOURCE /home)
 
-if [[ "$CURRENT_BOOT_DEV" == "/dev/mmcblk0p1" && "$CURRENT_ROOT_DEV" == "/dev/mmcblk0p5" ]]; then
-    echo "    Currently using partition set A (boot from p1, root from p5)"
+if [[ "$CURRENT_BOOT_DEV" == "/dev/mmcblk0p2" && "$CURRENT_ROOT_DEV" == "/dev/mmcblk0p5" ]]; then
+    echo "    Currently using partition set A (boot from p2, root from p5)"
     CURRENT_SET="A"
-    BOOT1_DEV=$CURRENT_BOOT_DEV
-elif [[ "$CURRENT_BOOT_DEV" == "/dev/mmcblk0p2" && "$CURRENT_ROOT_DEV" == "/dev/mmcblk0p6" ]]; then
-    echo "    Currently using partition set B (boot from p2, root from p6)"
+elif [[ "$CURRENT_BOOT_DEV" == "/dev/mmcblk0p3" && "$CURRENT_ROOT_DEV" == "/dev/mmcblk0p6" ]]; then
+    echo "    Currently using partition set B (boot from p3, root from p6)"
     CURRENT_SET="B"
-    BOOT1_DEV="/dev/mmcblk0p1"  # Always reference partition 1
 else
     echo "    WARNING: Mixed partition usage!"
     echo "    Boot from: $CURRENT_BOOT_DEV"
     echo "    Root from: $CURRENT_ROOT_DEV"
-    if [[ "$CURRENT_BOOT_DEV" == "/dev/mmcblk0p1" ]]; then
+    if [[ "$CURRENT_BOOT_DEV" == "/dev/mmcblk0p2" ]]; then
         CURRENT_SET="Mixed (boot A)"
-        BOOT1_DEV=$CURRENT_BOOT_DEV
-    elif [[ "$CURRENT_BOOT_DEV" == "/dev/mmcblk0p2" ]]; then
+    elif [[ "$CURRENT_BOOT_DEV" == "/dev/mmcblk0p3" ]]; then
         CURRENT_SET="Mixed (boot B)"
-        BOOT1_DEV="/dev/mmcblk0p1"  # Always reference partition 1
     else
         CURRENT_SET="Unknown"
-        BOOT1_DEV="/dev/mmcblk0p1"  # Default to partition 1
     fi
 fi
 
@@ -94,51 +102,49 @@ else
     echo "    [File does not exist]"
 fi
 
-echo_debug "Contents of /boot/tryboot.txt:"
+echo_debug "Checking for legacy files in /boot (these should NOT exist):"
 if [ -f "/boot/tryboot.txt" ]; then
+    echo_warning "Legacy tryboot.txt found in /boot - this should only be in CONFIGFS"
     cat /boot/tryboot.txt | sed 's/^/    /'
 else
-    echo "    [File does not exist]"
+    echo "    [No legacy tryboot.txt in /boot - correct]"
 fi
 
-echo_debug "Contents of /boot/autoboot.txt:"
 if [ -f "/boot/autoboot.txt" ]; then
+    echo_warning "Legacy autoboot.txt found in /boot - this should only be in CONFIGFS"
     cat /boot/autoboot.txt | sed 's/^/    /'
 else
-    echo "    [File does not exist]"
+    echo "    [No legacy autoboot.txt in /boot - correct]"
 fi
 
-echo_debug "Checking boot partition 1 autoboot.txt (controls boot device after power loss):"
+echo_debug "Checking CONFIGFS partition (p1) for autoboot.txt and tryboot.txt:"
 
-if [[ "$CURRENT_BOOT_DEV" != "/dev/mmcblk0p1" ]]; then
+CONFIGFS_DEV="/dev/mmcblk0p1"
+CONFIGFS_MNT=$(mktemp -d)
 
-    BOOT1_MNT=$(mktemp -d)
-    
-    if mount "$BOOT1_DEV" "$BOOT1_MNT"; then
-        if [ -f "$BOOT1_MNT/autoboot.txt" ]; then
-            echo "    Contents of partition 1 autoboot.txt:"
-            cat "$BOOT1_MNT/autoboot.txt" | sed 's/^/        /'
-            BOOT1_PARTITION=$(grep "boot_partition=" "$BOOT1_MNT/autoboot.txt" | sed 's/boot_partition=//')
-        else
-            echo "    [Partition 1 has no autoboot.txt file]"
-            BOOT1_PARTITION="None"
-        fi
-        
-        umount "$BOOT1_MNT"
+if mount "$CONFIGFS_DEV" "$CONFIGFS_MNT"; then
+    if [ -f "$CONFIGFS_MNT/autoboot.txt" ]; then
+        echo "    Contents of CONFIGFS autoboot.txt:"
+        cat "$CONFIGFS_MNT/autoboot.txt" | sed 's/^/        /'
+        BOOT1_PARTITION=$(grep "^boot_partition=" "$CONFIGFS_MNT/autoboot.txt" | head -1 | cut -d'=' -f2)
     else
-        echo "    [Failed to mount boot partition 1]"
-        BOOT1_PARTITION="Unknown"
-    fi
-    
-    rmdir "$BOOT1_MNT"
-else
-    if [ -f "/boot/autoboot.txt" ]; then
-        BOOT1_PARTITION=$(grep "boot_partition=" /boot/autoboot.txt | sed 's/boot_partition=//')
-    else
-        echo "    [Partition 1 has no autoboot.txt file]"
+        echo "    [CONFIGFS has no autoboot.txt file]"
         BOOT1_PARTITION="None"
     fi
+    
+    if [ -f "$CONFIGFS_MNT/tryboot.txt" ]; then
+        echo "    Contents of CONFIGFS tryboot.txt:"
+        cat "$CONFIGFS_MNT/tryboot.txt" | sed 's/^/        /'
+    else
+        echo "    [CONFIGFS has no tryboot.txt file]"
+    fi
+    umount "$CONFIGFS_MNT"
+else
+    echo_warning "Failed to mount CONFIGFS partition to check autoboot.txt"
+    BOOT1_PARTITION="Unknown"
 fi
+
+rmdir "$CONFIGFS_MNT"
 
 echo_debug "Partition layout:"
 lsblk -o NAME,SIZE,MOUNTPOINT,FSTYPE,LABEL,UUID,PARTUUID | sed 's/^/    /'
@@ -162,47 +168,20 @@ dmesg | grep -i -e mmc -e partition -e boot | head -20 | sed 's/^/    /'
 echo_debug "Bootloader version:"
 vcgencmd bootloader_version | sed 's/^/    /'
 
-BOOT1_DEV="/dev/mmcblk0p1"
 DEFAULT_BOOT="Unknown"
 
-if [[ "$CURRENT_BOOT_DEV" != "$BOOT1_DEV" ]]; then
-    BOOT1_MNT=$(mktemp -d)
-    
-    if mount "$BOOT1_DEV" "$BOOT1_MNT"; then
-        if [ -f "$BOOT1_MNT/autoboot.txt" ]; then
-            BOOT1_PARTITION=$(grep "boot_partition=" "$BOOT1_MNT/autoboot.txt" | sed 's/boot_partition=//')
-            
-            if [ "$BOOT1_PARTITION" = "1" ]; then
-                DEFAULT_BOOT="A"
-            elif [ "$BOOT1_PARTITION" = "2" ]; then
-                DEFAULT_BOOT="B"
-            fi
-        else
-            DEFAULT_BOOT="A (default without autoboot.txt)"
-        fi
-        umount "$BOOT1_MNT"
-    else
-        echo_warning "Failed to mount boot partition 1 to check autoboot.txt"
-    fi
-    rmdir "$BOOT1_MNT"
-else
-    if [ -f "/boot/autoboot.txt" ]; then
-        BOOT1_PARTITION=$(grep "boot_partition=" /boot/autoboot.txt | sed 's/boot_partition=//')
-        
-        if [ "$BOOT1_PARTITION" = "1" ]; then
-            DEFAULT_BOOT="A"
-        elif [ "$BOOT1_PARTITION" = "2" ]; then
-            DEFAULT_BOOT="B"
-        fi
-    else
-        DEFAULT_BOOT="A (default without autoboot.txt)"
-    fi
+if [ "$BOOT1_PARTITION" = "2" ]; then
+    DEFAULT_BOOT="A"
+elif [ "$BOOT1_PARTITION" = "3" ]; then
+    DEFAULT_BOOT="B"
+elif [ "$BOOT1_PARTITION" = "None" ]; then
+    DEFAULT_BOOT="A (default without autoboot.txt)"
 fi
 
 POWER_LOSS_BOOT="Unknown"
-if [ "$BOOT1_PARTITION" = "1" ]; then
+if [ "$BOOT1_PARTITION" = "2" ]; then
     POWER_LOSS_BOOT="A"
-elif [ "$BOOT1_PARTITION" = "2" ]; then
+elif [ "$BOOT1_PARTITION" = "3" ]; then
     POWER_LOSS_BOOT="B"
 elif [ "$BOOT1_PARTITION" = "None" ]; then
     POWER_LOSS_BOOT="A (default)"
@@ -214,9 +193,10 @@ echo_debug "Summary:"
 echo " - Currently on partition set: $CURRENT_SET"
 echo " - Current boot partition: $CURRENT_BOOT_DEV"
 echo " - Current root partition: $CURRENT_ROOT_DEV"
+echo " - Current home partition: $CURRENT_HOME_DEV"
 echo " - Default boot set in current autoboot.txt: $DEFAULT_BOOT"
-if [[ "$POWER_LOSS_BOOT" == "A" || "$POWER_LOSS_BOOT" == "B" || "$POWER_LOSS_BOOT" == "A (likely default)" ]]; then
+if [[ "$POWER_LOSS_BOOT" == "A" || "$POWER_LOSS_BOOT" == "B" || "$POWER_LOSS_BOOT" == "A (default)" ]]; then
     echo " - Partition set that will boot after power loss: $POWER_LOSS_BOOT"
 fi
-echo " - Boot partition 1 autoboot.txt setting: $(if [ "$BOOT1_PARTITION" = "None" ]; then echo "Not present"; else echo "$BOOT1_PARTITION"; fi)"
+echo " - CONFIGFS autoboot.txt setting: $(if [ "$BOOT1_PARTITION" = "None" ]; then echo "Not present"; else echo "$BOOT1_PARTITION"; fi)"
 echo_status "Done"

--- a/wlanpi1-lite/19-ab-scripts/files/commit-current-partition
+++ b/wlanpi1-lite/19-ab-scripts/files/commit-current-partition
@@ -6,7 +6,7 @@
 #
 # Requires: mount, blkid
 #
-# Version: v0.1
+# Version: v0.2
 # Author: Josh Schmelzle
 # License: BSD-3
 
@@ -38,33 +38,29 @@ CURRENT_BOOT=$(findmnt -n -o SOURCE /boot)
 echo_debug "Current root: $CURRENT_ROOT"
 echo_debug "Current boot: $CURRENT_BOOT"
 
-if [[ $CURRENT_ROOT == *"p5"* && $CURRENT_BOOT == *"p1"* ]]; then
-    echo_debug "Currently on partition set A (boot p1, root p5)"
+if [[ $CURRENT_ROOT == *"p5"* && $CURRENT_BOOT == *"p2"* ]]; then
+    echo_debug "Currently on partition set A (boot p2, root p5)"
     CURRENT_SET="A"
-    CURRENT_BOOT_NUM=1
-    ALT_BOOT_NUM=2
-    BOOT1_DEV=$CURRENT_BOOT
-elif [[ $CURRENT_ROOT == *"p6"* && $CURRENT_BOOT == *"p2"* ]]; then
-    echo_debug "Currently on partition set B (boot p2, root p6)"
-    CURRENT_SET="B"
     CURRENT_BOOT_NUM=2
-    ALT_BOOT_NUM=1
-    BOOT1_DEV="${CURRENT_BOOT/p2/p1}"
+    ALT_BOOT_NUM=3
+elif [[ $CURRENT_ROOT == *"p6"* && $CURRENT_BOOT == *"p3"* ]]; then
+    echo_debug "Currently on partition set B (boot p3, root p6)"
+    CURRENT_SET="B"
+    CURRENT_BOOT_NUM=3
+    ALT_BOOT_NUM=2
 else
     echo_warning "Detected mixed partition usage!"
     echo_debug "Root from: $CURRENT_ROOT"
     echo_debug "Boot from: $CURRENT_BOOT"
 
-    if [[ $CURRENT_BOOT == *"p1"* ]]; then
-        CURRENT_BOOT_NUM=1
-        ALT_BOOT_NUM=2
-        BOOT1_DEV=$CURRENT_BOOT
-        echo_debug "Using boot partition 1"
-    elif [[ $CURRENT_BOOT == *"p2"* ]]; then
+    if [[ $CURRENT_BOOT == *"p2"* ]]; then
         CURRENT_BOOT_NUM=2
-        ALT_BOOT_NUM=1
-        BOOT1_DEV="${CURRENT_BOOT/p2/p1}"
-        echo_debug "Using boot partition 2"
+        ALT_BOOT_NUM=3
+        echo_debug "Using boot partition 2 (set A)"
+    elif [[ $CURRENT_BOOT == *"p3"* ]]; then
+        CURRENT_BOOT_NUM=3
+        ALT_BOOT_NUM=2
+        echo_debug "Using boot partition 3 (set B)"
     else
         echo_error "Unable to determine boot partition number"
     fi
@@ -72,25 +68,30 @@ fi
 
 echo_status "Committing to current partition set ..."
 
-# Always update autoboot.txt on partition 1 (boot A)
-echo_debug "Mounting boot partition 1 (the default boot partition) ..."
-BOOT1_MNT=$(mktemp -d)
-mount "$BOOT1_DEV" "$BOOT1_MNT"
+# Always update autoboot.txt on CONFIGFS partition (p1)
+echo_debug "Mounting CONFIGFS partition (p1) ..."
+CONFIGFS_DEV="/dev/mmcblk0p1"
+CONFIGFS_MNT=$(mktemp -d)
+mount "$CONFIGFS_DEV" "$CONFIGFS_MNT"
 
-echo_debug "Updating autoboot.txt on boot partition 1 to point to boot partition $CURRENT_BOOT_NUM ..."
-cat > "$BOOT1_MNT/autoboot.txt" << EOF
+echo_debug "Updating autoboot.txt on CONFIGFS to point to boot partition $CURRENT_BOOT_NUM ..."
+cat > "$CONFIGFS_MNT/autoboot.txt" << EOF
 [all]
 boot_partition=$CURRENT_BOOT_NUM
 tryboot_a_b=1
 EOF
 
-echo_debug "New autoboot.txt content on boot partition 1:"
-cat "$BOOT1_MNT/autoboot.txt" | sed 's/^/    /'
+echo_debug "New autoboot.txt content on CONFIGFS:"
+cat "$CONFIGFS_MNT/autoboot.txt" | sed 's/^/    /'
 
-umount "$BOOT1_MNT"
-rmdir "$BOOT1_MNT"
+umount "$CONFIGFS_MNT"
+rmdir "$CONFIGFS_MNT"
 
 echo_status "Partition commit complete"
-echo_debug "Partition set $CURRENT_SET is now the default boot option"
+echo_debug "Summary:"
+echo " - Committed partition set: $CURRENT_SET"
+echo " - Active boot partition: $CURRENT_BOOT_NUM" 
+echo " - Alternative boot partition: $ALT_BOOT_NUM"
+echo " - CONFIGFS autoboot.txt now points to partition $CURRENT_BOOT_NUM"
 echo_debug "This configuration will persist across all future reboots and power cycles"
 echo

--- a/wlanpi1-lite/19-ab-scripts/files/tryboot-alternate
+++ b/wlanpi1-lite/19-ab-scripts/files/tryboot-alternate
@@ -85,12 +85,12 @@ echo
 echo_debug "IMPORTANT: This performs a one-time boot test to partition set $TARGET_SET"
 echo_debug "If the test boot fails, the system will automatically revert to partition set $ACTIVE_SET on next boot"
 echo
-echo -e "To test, run:\n\033[1msudo reboot '0 tryboot'\033[0m"
+echo -e "To test, run:\n\033[1msudo reboot '${TARGET_BOOT_NUM} tryboot'\033[0m"
 echo
 echo_debug "Boot process explanation:"
-echo " - reboot '0 tryboot' → bootloader reads CONFIGFS (p1)"
-echo " - finds tryboot.txt → reads os_prefix=${TARGET_BOOT_NUM}:/"
-echo " - boots from partition ${TARGET_BOOT_NUM} (partition set ${TARGET_SET})"
+echo " - reboot '${TARGET_BOOT_NUM} tryboot' → bootloader boots from partition ${TARGET_BOOT_NUM}"
+echo " - uses tryboot.txt configuration from CONFIGFS (p1)" 
+echo " - boots partition set ${TARGET_SET}"
 echo 
 echo -e "After verifying the alternate partition works correctly, from the alternate partition apply with:\n\033[1msudo commit-current-partition\033[0m"
 echo

--- a/wlanpi1-lite/19-ab-scripts/files/tryboot-alternate
+++ b/wlanpi1-lite/19-ab-scripts/files/tryboot-alternate
@@ -6,7 +6,10 @@
 # If the alternate set fails to boot, the system will revert to 
 # the original partition set on the next boot
 #
-# Version: v0.2
+# Usage: tryboot-alternate [--check]
+#   --check: Show what would be done without rebooting
+#
+# Version: v0.3
 # Author:  Josh Schmelzle
 # License: BSD-3
 
@@ -26,6 +29,24 @@ echo_error() {
     echo -e "\e[1;31mERROR: $1\e[0m"
     exit 1
 }
+
+CHECK_ONLY=false
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --check)
+            CHECK_ONLY=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--check]"
+            echo "  --check: Show what would be done without rebooting"
+            exit 0
+            ;;
+        *)
+            echo_error "Unknown option: $1\nUse --help for usage information"
+            ;;
+    esac
+done
 
 if [ "$(id -u)" -ne 0 ]; then
     echo_error "Need elevated permissions ... run as root (sudo) ..."
@@ -66,7 +87,11 @@ if mount "$CONFIGFS_DEV" "$CONFIGFS_MNT"; then
             echo_debug "tryboot.txt correctly configured for partition set $TARGET_SET"
         else
             echo_warning "Updating tryboot.txt to properly point to partition set $TARGET_SET"
-            sed -i "s|os_prefix=[0-9]\+:/|os_prefix=${TARGET_BOOT_NUM}:/|" "$CONFIGFS_MNT/tryboot.txt"
+            if [ "$CHECK_ONLY" = false ]; then
+                sed -i "s|os_prefix=[0-9]\+:/|os_prefix=${TARGET_BOOT_NUM}:/|" "$CONFIGFS_MNT/tryboot.txt"
+            else
+                echo_debug "Would update tryboot.txt os_prefix to ${TARGET_BOOT_NUM}:/"
+            fi
         fi
         echo_debug "Content of tryboot.txt:"
         cat "$CONFIGFS_MNT/tryboot.txt" | sed 's/^/    /'
@@ -85,8 +110,6 @@ echo
 echo_debug "IMPORTANT: This performs a one-time boot test to partition set $TARGET_SET"
 echo_debug "If the test boot fails, the system will automatically revert to partition set $ACTIVE_SET on next boot"
 echo
-echo -e "To test, run:\n\033[1msudo reboot '${TARGET_BOOT_NUM} tryboot'\033[0m"
-echo
 echo_debug "Boot process explanation:"
 echo " - reboot '${TARGET_BOOT_NUM} tryboot' → bootloader boots from partition ${TARGET_BOOT_NUM}"
 echo " - uses tryboot.txt configuration from CONFIGFS (p1)" 
@@ -94,3 +117,11 @@ echo " - boots partition set ${TARGET_SET}"
 echo 
 echo -e "After verifying the alternate partition works correctly, from the alternate partition apply with:\n\033[1msudo commit-current-partition\033[0m"
 echo
+if [ "$CHECK_ONLY" = true ]; then
+    echo_status "Check mode - would execute: reboot '${TARGET_BOOT_NUM} tryboot'"
+    echo_debug "Use 'sudo tryboot-alternate' to apply and reboot"
+    echo
+else
+    echo_status "Rebooting to test partition set $TARGET_SET..."
+    reboot "${TARGET_BOOT_NUM} tryboot"
+fi

--- a/wlanpi1-lite/19-ab-scripts/files/tryboot-alternate
+++ b/wlanpi1-lite/19-ab-scripts/files/tryboot-alternate
@@ -6,7 +6,7 @@
 # If the alternate set fails to boot, the system will revert to 
 # the original partition set on the next boot
 #
-# Version: v0.1
+# Version: v0.2
 # Author:  Josh Schmelzle
 # License: BSD-3
 
@@ -37,15 +37,15 @@ CURRENT_ROOT=$(mount | grep ' on / ' | awk '{print $1}')
 echo_debug "Current root: $CURRENT_ROOT"
 
 if [[ $CURRENT_ROOT == *"mmcblk0p5"* ]]; then
-    echo_debug "Currently booted from A partition set (boot p1, root p5)"
+    echo_debug "Currently booted from A partition set (boot p2, root p5)"
     ACTIVE_SET="A"
     TARGET_SET="B"
-    TARGET_BOOT_NUM=2
+    TARGET_BOOT_NUM=3
 elif [[ $CURRENT_ROOT == *"mmcblk0p6"* ]]; then
-    echo_debug "Currently booted from B partition set (boot p2, root p6)"
+    echo_debug "Currently booted from B partition set (boot p3, root p6)"
     ACTIVE_SET="B"
     TARGET_SET="A"
-    TARGET_BOOT_NUM=1
+    TARGET_BOOT_NUM=2
 else
     echo_error "Unable to determine current boot partition ...\nCurrent root: $CURRENT_ROOT"
 fi
@@ -55,25 +55,42 @@ echo_debug "This will not change your default boot partition"
 echo_debug "If boot fails, system will revert to partition set $ACTIVE_SET on next boot"
 
 echo_debug "Verifying tryboot.txt configuration for target partition set ..."
-if [ -f "/boot/tryboot.txt" ]; then
-    if grep -q "os_prefix=${TARGET_BOOT_NUM}:/" "/boot/tryboot.txt"; then
-        echo_debug "tryboot.txt correctly configured for partition set $TARGET_SET"
+
+# Mount CONFIGFS to access tryboot.txt
+CONFIGFS_DEV="/dev/mmcblk0p1"
+CONFIGFS_MNT=$(mktemp -d)
+
+if mount "$CONFIGFS_DEV" "$CONFIGFS_MNT"; then
+    if [ -f "$CONFIGFS_MNT/tryboot.txt" ]; then
+        if grep -q "os_prefix=${TARGET_BOOT_NUM}:/" "$CONFIGFS_MNT/tryboot.txt"; then
+            echo_debug "tryboot.txt correctly configured for partition set $TARGET_SET"
+        else
+            echo_warning "Updating tryboot.txt to properly point to partition set $TARGET_SET"
+            sed -i "s|os_prefix=[0-9]\+:/|os_prefix=${TARGET_BOOT_NUM}:/|" "$CONFIGFS_MNT/tryboot.txt"
+        fi
+        echo_debug "Content of tryboot.txt:"
+        cat "$CONFIGFS_MNT/tryboot.txt" | sed 's/^/    /'
     else
-        echo_warning "Updating tryboot.txt to properly point to partition set $TARGET_SET"
-        sed -i "s|os_prefix=[0-9]\+:/|os_prefix=${TARGET_BOOT_NUM}:/|" "/boot/tryboot.txt"
+        echo_error "tryboot.txt not found in CONFIGFS partition."
     fi
-    echo_debug "Content of tryboot.txt:"
-    cat /boot/tryboot.txt | sed 's/^/    /'
+    umount "$CONFIGFS_MNT"
 else
-    echo_error "tryboot.txt not found in /boot."
+    echo_error "Failed to mount CONFIGFS partition to access tryboot.txt"
 fi
+
+rmdir "$CONFIGFS_MNT"
 
 echo_status "Ready to tryboot to partition set $TARGET_SET"
 echo
 echo_debug "IMPORTANT: This performs a one-time boot test to partition set $TARGET_SET"
 echo_debug "If the test boot fails, the system will automatically revert to partition set $ACTIVE_SET on next boot"
 echo
-echo -e "To test, run:\n\033[1msudo reboot '$TARGET_BOOT_NUM tryboot'\033[0m"
+echo -e "To test, run:\n\033[1msudo reboot '0 tryboot'\033[0m"
 echo
+echo_debug "Boot process explanation:"
+echo " - reboot '0 tryboot' → bootloader reads CONFIGFS (p1)"
+echo " - finds tryboot.txt → reads os_prefix=${TARGET_BOOT_NUM}:/"
+echo " - boots from partition ${TARGET_BOOT_NUM} (partition set ${TARGET_SET})"
+echo 
 echo -e "After verifying the alternate partition works correctly, from the alternate partition apply with:\n\033[1msudo commit-current-partition\033[0m"
 echo

--- a/wlanpi1-lite/19-ab-scripts/files/update-alternate-partition
+++ b/wlanpi1-lite/19-ab-scripts/files/update-alternate-partition
@@ -359,7 +359,8 @@ TARGET_SET=$INACTIVE_SET
 SOURCE_SET=$ACTIVE_SET
 
 echo "1. Test the updated $TARGET_SET partition set:"
-echo "   sudo reboot '0 tryboot'"
+echo "   sudo tryboot-alternate"
+echo "   sudo reboot '${TARGET_BOOT_NUM} tryboot'"
 echo
 echo "2. After booting to $TARGET_SET, verify system functionality:"
 echo "   sudo boot-info"

--- a/wlanpi1-lite/19-ab-scripts/files/update-alternate-partition
+++ b/wlanpi1-lite/19-ab-scripts/files/update-alternate-partition
@@ -6,7 +6,7 @@
 #
 # Requires: gunzip dd blkid mount sed
 #
-# Version: v0.5
+# Version: v0.6
 # Author: Josh Schmelzle
 # License: BSD-3
 
@@ -74,27 +74,27 @@ CURRENT_ROOT=$(mount | grep ' on / ' | awk '{print $1}')
 echo_debug "Current root: $CURRENT_ROOT"
 
 if [[ $CURRENT_ROOT == *"mmcblk0p5"* ]]; then
-    echo_debug "Currently booted from A partition set (boot p1, root p5)"
+    echo_debug "Currently booted from A partition set (boot p2, root p5)"
     ACTIVE_SET="A"
-    INACTIVE_BOOT="/dev/mmcblk0p2"
+    INACTIVE_BOOT="/dev/mmcblk0p3"
     INACTIVE_ROOT="/dev/mmcblk0p6"
-    ACTIVE_BOOT="/dev/mmcblk0p1"
+    ACTIVE_BOOT="/dev/mmcblk0p2"
     ACTIVE_ROOT="/dev/mmcblk0p5"
     HOME_PART="/dev/mmcblk0p7"
-    BOOT_PARTITION=1
-    INACTIVE_BOOT_NUM=2
-    ACTIVE_BOOT_NUM=1
+    BOOT_PARTITION=2
+    INACTIVE_BOOT_NUM=3
+    ACTIVE_BOOT_NUM=2
 elif [[ $CURRENT_ROOT == *"mmcblk0p6"* ]]; then
-    echo_debug "Currently booted from B partition set (boot p2, root p6)"
+    echo_debug "Currently booted from B partition set (boot p3, root p6)"
     ACTIVE_SET="B"
-    INACTIVE_BOOT="/dev/mmcblk0p1"
+    INACTIVE_BOOT="/dev/mmcblk0p2"
     INACTIVE_ROOT="/dev/mmcblk0p5"
-    ACTIVE_BOOT="/dev/mmcblk0p2"
+    ACTIVE_BOOT="/dev/mmcblk0p3"
     ACTIVE_ROOT="/dev/mmcblk0p6"
     HOME_PART="/dev/mmcblk0p7"
-    BOOT_PARTITION=2
-    INACTIVE_BOOT_NUM=1
-    ACTIVE_BOOT_NUM=2
+    BOOT_PARTITION=3
+    INACTIVE_BOOT_NUM=2
+    ACTIVE_BOOT_NUM=3
 else
     echo_error "Unable to determine current boot partition ...\nCurrent root: $CURRENT_ROOT"
 fi
@@ -232,8 +232,8 @@ if [ $ROOT_IMAGE_SIZE_BYTES -gt $ROOT_TARGET_SIZE ]; then
 fi
 
 echo_debug "Verifying target partitions ..."
-if [[ "$INACTIVE_BOOT" != "/dev/mmcblk0p1" && "$INACTIVE_BOOT" != "/dev/mmcblk0p2" ]]; then
-    echo_error "Invalid boot target: $INACTIVE_BOOT - should be either p1 or p2"
+if [[ "$INACTIVE_BOOT" != "/dev/mmcblk0p2" && "$INACTIVE_BOOT" != "/dev/mmcblk0p3" ]]; then
+    echo_error "Invalid boot target: $INACTIVE_BOOT - should be either p2 or p3"
 fi
 
 if [[ "$INACTIVE_ROOT" != "/dev/mmcblk0p5" && "$INACTIVE_ROOT" != "/dev/mmcblk0p6" ]]; then
@@ -318,14 +318,23 @@ cat "$TEMP_DIR/mnt_boot/cmdline-b.txt" | sed 's/^/    /'
 echo_debug "--------------------------------"
 echo
 
-echo_debug "Creating tryboot.txt ..."
-cat > "$TEMP_DIR/mnt_boot/tryboot.txt" << EOF
+echo_debug "Creating/updating tryboot.txt in CONFIGFS ..."
+CONFIGFS_DEV="/dev/mmcblk0p1"
+CONFIGFS_MNT=$(mktemp -d -p "$TEMP_DIR")
+
+if mount "$CONFIGFS_DEV" "$CONFIGFS_MNT"; then
+    cat > "$CONFIGFS_MNT/tryboot.txt" << EOF
 # This configuration will be used when booting in tryboot mode
 # Point to the alternate partition
 kernel=wlanpi-kernel8.img
 os_prefix=$ACTIVE_BOOT_NUM:/
 cmdline=cmdline-b.txt
 EOF
+    echo_debug "Updated tryboot.txt in CONFIGFS"
+    umount "$CONFIGFS_MNT"
+else
+    echo_warning "Failed to mount CONFIGFS partition to update tryboot.txt"
+fi
 
 echo_debug "Updating fstab in inactive root partition ..."
 cat > "$TEMP_DIR/mnt_root/etc/fstab" << EOF
@@ -350,7 +359,7 @@ TARGET_SET=$INACTIVE_SET
 SOURCE_SET=$ACTIVE_SET
 
 echo "1. Test the updated $TARGET_SET partition set:"
-echo "   sudo reboot '$TARGET_BOOT_NUM tryboot'"
+echo "   sudo reboot '0 tryboot'"
 echo
 echo "2. After booting to $TARGET_SET, verify system functionality:"
 echo "   sudo boot-info"
@@ -358,12 +367,12 @@ echo
 echo "3. If $TARGET_SET is working properly and you want to make it permanent:"
 echo "   sudo commit-current-partition"
 echo
-echo "   This updates partition 1's autoboot.txt to boot partition $TARGET_BOOT_NUM"
+echo "   This updates CONFIGFS autoboot.txt to boot partition $TARGET_BOOT_NUM"
 echo "   on next reboot and after any power loss."
 echo
 echo "4. To return to partition set $SOURCE_SET without making changes permanent:"
 echo "   sudo reboot"
 echo
-echo "IMPORTANT: The autoboot.txt file on partition 1 ALWAYS controls which"
+echo "IMPORTANT: The autoboot.txt file in CONFIGFS (p1) ALWAYS controls which"
 echo "partition boots after a power loss, regardless of your current partition."
 echo


### PR DESCRIPTION
## Type of change 

This PR is a maintenance task on the migration of the A/B partition boot system from storing boot configuration files directly in boot partitions to using a dedicated CONFIGFS partition.

This change improves partition management and boot configuration.

<!-- *Pick at least one.* -->

* [X] Bug fix (non-breaking change that fixes something)
* [X] Documentation update (readme, changelog, man page, etc.)
* [X] New feature (non-breaking change adding functionality)
* [X] Breaking change (fix or feature changing existing functionality)
* [X] Code quality improvement (refactor, performance improvements)

## New Partition Layout

- p1: CONFIGFS (16MB) - Contains autoboot.txt and tryboot.txt
- p2: BOOT1FS (256MB) - Boot partition A
- p3: BOOT2FS (256MB) - Boot partition B
- p4: Extended partition container
- p5: ROOT1FS - Root partition A
- p6: ROOT2FS - Root partition B
- p7: HOME - Shared persistent partition

`scripts/ab-partition`:

- Added 16MB CONFIGFS partition as p1
- Updated partition numbering throughout (boot partitions now p2/p3)
- Modified boot configuration to use CONFIGFS for A/B management
- Enhanced home partition expansion script with better error handling and logging
- Fixed filesystem creation and partition alignment

## CI/CD Updates:

- Updated GitHub workflow verification to check CONFIGFS partition
- Fixed mount point validation for new partition structure

## Partition management tools

All bash based A/B management scripts have been updated for the new partition layout:

`boot-info` (v0.1 → v0.2):

- Now reads boot configuration from CONFIGFS partition
- Updated partition references (p1→p2, p2→p3)
- Added legacy file detection in /boot
- Enhanced partition analysis and summary output

`commit-current-partition` (v0.1 → v0.2):

- Updates autoboot.txt in CONFIGFS instead of boot partition
- Simplified logic by centralizing configuration management
- Better error handling and status reporting

`tryboot-alternate`(v0.1 → v0.3):

- Added --check flag for dry-run validation
- Now automatically reboots to test alternate partition
- Reads/writes tryboot configuration from CONFIGFS
- Improved user experience with immediate testing

`update-alternate-partition` (v0.5 → v0.6):

- Updates tryboot configuration in CONFIGFS during partition updates
- Fixed partition references for new layout
- Improved error handling and user guidance

## Breaking change

<!-- *Does this Pull Request introduce a breaking change?* -->

- What functionality breaks? Not compatible with older images
- Why does it break? Partition changes
- How should it be migrated? Flash new AB partition image
- Are there any backward-compatible alternatives? No

## Testing

<!-- *Please explain how you tested this change manually, and if applicable, what new tests you added.* -->

Tested on 16 GB eMMC locally.

## Checklist

<!-- No PR without a related GH issue! Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, homing pigeon, or slack are great starting points, but **do not count** for this requirement. --> 

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [X] I linked a GitHub issue to this PR (in the next section). 
* [X] I have added or updated the documentation (if applicable)

## Related Issues/PRs

<!-- *Pick at least one. Delete the other lines.* -->

- This PR is related to issue #24