### PR TITLE
Add systemd-timesyncd to fix time when network is available

### DIFF
--- a/wlanpi1-lite/04-set-timezone/00-packages
+++ b/wlanpi1-lite/04-set-timezone/00-packages
@@ -1,0 +1,1 @@
+systemd-timesyncd

--- a/wlanpi2-full/04-set-timezone/00-packages
+++ b/wlanpi2-full/04-set-timezone/00-packages
@@ -1,0 +1,1 @@
+systemd-timesyncd


### PR DESCRIPTION
## Type of change 

<!--
Feel free to remove sections and items that don't pertain to the context of your PR.
For example, if you're updating docs, you don't need the testing section.
Note that you do not need to delete these HTML comments as they are not visible after the PR is submitted.
-->

<!-- *Pick at least one.* -->

* [X] Bug fix (non-breaking change that fixes something)
* [ ] Documentation update (readme, changelog, man page, etc.)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature changing existing functionality)
* [ ] Code quality improvement (refactor, performance improvements)
* [ ] Other (please specify):

## Proposed change

<!-- *Please describe the purpose of this change, the problem it solves, and why the change is necessary. Including code snippets or links to related documentation when applicable will assist approval.* -->

Adds systemd-timesyncd to sync datetime when network is available.

## Testing

<!-- *Please explain how you tested this change manually, and if applicable, what new tests you added.* -->

Tested locally:

```
wlanpi@wlanpi-e69:~ $ date
Tue Jul  8 11:20:58 PM CDT 2025
wlanpi@wlanpi-e69:~ $ sudo apt install systemd-timesyncd
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  systemd-timesyncd
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 61.8 kB of archives.
After this operation, 163 kB of additional disk space will be used.
Get:1 http://deb.debian.org/debian-security bookworm-security/main arm64 systemd-timesyncd arm64 252.38-1~deb12u1 [61.8 kB]
Fetched 61.8 kB in 0s (362 kB/s)           
Selecting previously unselected package systemd-timesyncd.
(Reading database ... 35396 files and directories currently installed.)
Preparing to unpack .../systemd-timesyncd_252.38-1~deb12u1_arm64.deb ...
Unpacking systemd-timesyncd (252.38-1~deb12u1) ...
Setting up systemd-timesyncd (252.38-1~deb12u1) ...
Creating group 'systemd-timesync' with GID 992.
Creating user 'systemd-timesync' (systemd Time Synchronization) with UID 992 and GID 992.
Created symlink /etc/systemd/system/dbus-org.freedesktop.timesync1.service → /lib/systemd/system/systemd-timesyncd.service.
Created symlink /etc/systemd/system/sysinit.target.wants/systemd-timesyncd.service → /lib/systemd/system/systemd-timesyncd.service.
Processing triggers for dbus (1.14.10-1~deb12u1) ...
wlanpi@wlanpi-e69:~ $ 
wlanpi@wlanpi-e69:~ $ date
Fri Sep 26 01:27:46 PM CDT 2025
```

## Checklist

<!-- No PR without a related GH issue! Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, homing pigeon, or slack are great starting points, but **do not count** for this requirement. --> 

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [ ] I ran the test suite and verified it succeeded
* [X] I linked a GitHub issue to this PR (in the next section). 
* [ ] I have updated the changelog (if applicable)
* [ ] I have added or updated the documentation (if applicable)

## Related Issues/PRs

<!-- *Pick at least one. Delete the other lines.* -->

- This PR fixes/closes issue #64 
- This PR is related to issue #
- This PR depends on/blocks PR #