### PR TITLE
Add eth1.network configuration

### DIFF
--- a/wlanpi1-lite/02-net-tweaks/02-run.sh
+++ b/wlanpi1-lite/02-net-tweaks/02-run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+echo "Copying eth1.network file ..."
+copy_overlay /etc/systemd/network/eth1.network -o root -g root -m 644

--- a/wlanpi1-lite/02-net-tweaks/files/etc/systemd/network/eth1.network
+++ b/wlanpi1-lite/02-net-tweaks/files/etc/systemd/network/eth1.network
@@ -1,0 +1,15 @@
+[Match]
+Name=eth1
+
+[Network]
+DHCP=ipv4
+LinkLocalAddressing=no
+IPv6AcceptRA=no
+
+[DHCP]
+UseDNS=yes
+UseRoutes=yes
+UseMTU=yes
+SendHostname=yes
+UseHostname=no
+ClientIdentifier=mac

--- a/wlanpi1-lite/04-set-timezone/00-packages
+++ b/wlanpi1-lite/04-set-timezone/00-packages
@@ -1,0 +1,1 @@
+systemd-timesyncd

--- a/wlanpi2-full/04-set-timezone/00-packages
+++ b/wlanpi2-full/04-set-timezone/00-packages
@@ -1,0 +1,1 @@
+systemd-timesyncd


### PR DESCRIPTION
## Type of change 

<!--
Feel free to remove sections and items that don't pertain to the context of your PR.
For example, if you're updating docs, you don't need the testing section.
Note that you do not need to delete these HTML comments as they are not visible after the PR is submitted.
-->

<!-- *Pick at least one.* -->

* [ ] Bug fix (non-breaking change that fixes something)
* [ ] Documentation update (readme, changelog, man page, etc.)
* [X] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature changing existing functionality)
* [ ] Code quality improvement (refactor, performance improvements)
* [ ] Other (please specify):

## Proposed change

<!-- *Please describe the purpose of this change, the problem it solves, and why the change is necessary. Including code snippets or links to related documentation when applicable will assist approval.* -->

Adds DHCPv4 client configuration for eth1 specifically for static or leave behind scenarios of the WLAN Pi Go powered by adapters like the PROCET Gigabit PoE to USB-C adapter.

## Testing

Tested manually:

```
wlanpi@wlanpi-e69:/etc/systemd/network $ cat eth1.network 
[Match]
Name=eth1

[Network]
DHCP=ipv4
LinkLocalAddressing=no
IPv6AcceptRA=no

[DHCP]
UseDNS=yes
UseRoutes=yes
UseMTU=yes
SendHostname=yes
UseHostname=no
ClientIdentifier=mac
wlanpi@wlanpi-e69:/etc/systemd/network $ ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host noprefixroute 
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether 2c:cf:67:32:8e:69 brd ff:ff:ff:ff:ff:ff
3: wlan0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether c8:15:4e:8a:2e:42 brd ff:ff:ff:ff:ff:ff
4: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 8c:51:09:20:2e:40 brd ff:ff:ff:ff:ff:ff
    inet 192.168.17.201/24 metric 1024 brd 192.168.17.255 scope global dynamic eth1
       valid_lft 2630sec preferred_lft 2630sec
wlanpi@wlanpi-e69:/etc/systemd/network $ dmesg | grep usb2
[    4.854348] usb usb2: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 6.12
[    4.854360] usb usb2: New USB device strings: Mfr=3, Product=2, SerialNumber=1
[    4.854366] usb usb2: Product: DWC OTG Controller
[    4.854370] usb usb2: Manufacturer: Linux 6.12.22-v8-wlanpi+ dwc2_hsotg
[    4.854375] usb usb2: SerialNumber: fe980000.usb
wlanpi@wlanpi-e69:/etc/systemd/network $ lsusb
Bus 002 Device 002: ID 0bda:8153 Realtek Semiconductor Corp. RTL8153 Gigabit Ethernet Adapter
```

## Checklist

<!-- No PR without a related GH issue! Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, homing pigeon, or slack are great starting points, but **do not count** for this requirement. --> 

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [ ] I ran the test suite and verified it succeeded
* [X] I linked a GitHub issue to this PR (in the next section). 
* [ ] I have updated the changelog (if applicable)
* [ ] I have added or updated the documentation (if applicable)

## Related Issues/PRs

<!-- *Pick at least one. Delete the other lines.* -->

- This PR fixes/closes issue #69 
- This PR is related to issue #
- This PR depends on/blocks PR #