### PR TITLE
Improve wlanpi1-lite first-boot script with better error handling and logging

### DIFF
--- a/wlanpi1-lite/10-first-boot/files/lib/systemd/system/wlanpi-first-boot.service
+++ b/wlanpi1-lite/10-first-boot/files/lib/systemd/system/wlanpi-first-boot.service
@@ -1,12 +1,17 @@
 [Unit]
 Description=Script executed only once at the first boot to finish image configurations
+After=network-online.target ufw.service local-fs.target
+Wants=network-online.target
+Requires=local-fs.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/first-boot.sh
 ExecStartPre=/usr/bin/test ! -f /var/lib/first-boot-done
-ExecStartPost=/usr/bin/touch /var/lib/first-boot-done
+ExecStart=/usr/bin/first-boot.sh
+ExecStartPost=/bin/sh -c '[ $SERVICE_RESULT = success ] && touch /var/lib/first-boot-done || exit 0'
 RemainAfterExit=yes
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/wlanpi1-lite/10-first-boot/files/usr/bin/first-boot.sh
+++ b/wlanpi1-lite/10-first-boot/files/usr/bin/first-boot.sh
@@ -1,64 +1,73 @@
 #!/bin/bash
+set -euo pipefail
 
-set -e 
+LOGFILE="/var/log/wlanpi-firstboot.log"
+mkdir -p "$(dirname "$LOGFILE")" 2>/dev/null || true
+exec > >(tee -a "$LOGFILE") 2>&1
 
-raspi-config nonint do_wifi_country US || echo "WARNING: failed to set country code"
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
 
-echo '#!/bin/sh
-echo "Welcome to WLAN Pi OS. This device is intended for educational, laboratory, and non-commercial testing purposes. WLAN Pi provides ABSOLUTELY NO WARRANTY. You are solely responsible for complying with applicable laws and regulations."' > /etc/update-motd.d/20-wlanpi-legal
-chmod +x /etc/update-motd.d/20-wlanpi-legal
+log "Starting first boot configuration"
 
-if ! command -v ufw >/dev/null 2>&1; then
-    echo "ufw not found ..."
+log "Setting Wi-Fi country to US"
+if raspi-config nonint do_wifi_country US; then
+    log "Wi-Fi country set successfully"
 else
-    # ensure UFW is configured
-    ufw default deny incoming
-    ufw default allow outgoing
-    
-    ssh_rule_added=false
-
-    # SSH
-    ufw allow 22/tcp
-    
-    # oscium-spectrum
-    ufw allow 3264/tcp
-    ufw allow 3264/udp
-
-    # oscium-capture
-    ufw allow 6174/tcp
-    ufw allow 6174/udp
-
-    # DHCP server
-    ufw allow 67/udp
-
-    # ephemeral/avahi-related port
-    ufw allow 36872/udp
-
-    # mDNS (IPv4 multicast)
-    ufw allow proto udp from 224.0.0.0/4 to any port 5353
-
-    # mDNS (IPv6 link-local multicast)
-    ufw allow proto udp from fe80::/10 to any port 5353
-
-    ufw logging on
-
-    if ! ufw status verbose | grep -q "22/tcp.*ALLOW"; then
-        echo "WARNING: SSH rule not properly added ... retrying ..."
-        ufw delete allow 22/tcp 2>/dev/null || true
-        if ufw allow 22/tcp; then
-            ssh_rule_added=true
-        fi
-    else
-        ssh_rule_added=true
-    fi
-
-    if [[ "$ssh_rule_added" == true ]]; then
-        ufw --force enable
-        echo "ufw enabled after force ..."
-    else
-        echo "WARNING: SSH not in firewall rules. ufw not enabled to prevent lockout ..."
-        exit 1
-    fi
+    log "WARNING: failed to set country code"
 fi
 
+if echo '#!/bin/sh
+echo "Welcome to WLAN Pi OS. This device is intended for educational, laboratory, and non-commercial testing purposes. WLAN Pi provides ABSOLUTELY NO WARRANTY. You are solely responsible for complying with applicable laws and regulations."' > /etc/update-motd.d/20-wlanpi-legal && chmod +x /etc/update-motd.d/20-wlanpi-legal; then
+    log "Legal notice MOTD created successfully"
+else
+    log "ERROR: Failed to create MOTD"
+    exit 1
+fi
+
+log "Checking for ufw"
+if ! command -v ufw >/dev/null 2>&1; then
+    log "WARNING: ufw not found, skipping firewall configuration"
+    exit 0
+fi
+
+log "Configuring firewall rules"
+
+ufw allow 22/tcp
+log "Added SSH (port 22/tcp)"
+
+ufw allow 67/udp
+log "Added DHCP server (port 67/udp)"
+
+ufw allow 36872/udp
+log "Added ephemeral/avahi-related (port 36872/udp)"
+
+ufw allow proto udp from 224.0.0.0/4 to any port 5353
+log "Added mDNS IPv4 multicast rule"
+
+ufw allow proto udp from fe80::/10 to any port 5353
+log "Added mDNS IPv6 link-local rule"
+
+ufw allow 3264/tcp
+ufw allow 3264/udp
+log "Added oscium-spectrum ports (3264/tcp 3264/udp)"
+
+ufw allow 6174/tcp
+ufw allow 6174/udp
+log "Added oscium-capture ports (6174/tcp 6174/udp)"
+
+log "Setting firewall defaults"
+ufw default deny incoming
+ufw default allow outgoing
+log "Firewall defaults set (deny incoming, allow outgoing)"
+
+# log "Enabling firewall logging"
+# ufw logging on
+
+log "Enabling firewall"
+ufw --force enable
+log "Firewall enabled successfully"
+
+log "First boot configuration completed"
 exit 0


### PR DESCRIPTION
## Type of change 

<!--
Feel free to remove sections and items that don't pertain to the context of your PR.
For example, if you're updating docs, you don't need the testing section.
Note that you do not need to delete these HTML comments as they are not visible after the PR is submitted.
-->

<!-- *Pick at least one.* -->

* [X] Code quality improvement (refactor, performance improvements)

## Proposed change

<!-- *Please describe the purpose of this change, the problem it solves, and why the change is necessary. Including code snippets or links to related documentation when applicable will assist approval.* -->

### Service file (`wlanpi-first-boot.service`)

- Added dependency ordering: `After=network-online.target ufw.service local-fs.target`
- Added `Wants=network-online.target` to ensure network is available
- Added `Requires=local-fs.target` to ensure filesystem is mounted
- Fixed `ExecStartPost` to only create done file on success
- Added explicit journal output configuration

### First-boot script (`first-boot.sh`)

- Added logging to `/var/log/wlanpi-firstboot.log` and systemd journal
- Improved error handling with `set -euo pipefail`
- Simplified firewall configuration logic by removing complex retry/verification patterns
- Reordered firewall operations: rules first, then defaults, then enable
- Removed UFW logging to prevent excessive disk wear
- Added log messages for each configuration step

## LLM/AI Usage

Sonnet 4.5 assisted with this PR.

## Testing

<!-- *Please explain how you tested this change manually, and if applicable, what new tests you added.* -->

- [ ] Did you add new automated tests? If yes, explain which edge cases are covered.
- [ ] Does this change affect any existing tests? If so, how did you adjust them?
- [ ] Please provide test run results or screenshots if applicable.

## Checklist

<!-- No PR without a related GH issue! Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, homing pigeon, or slack are great starting points, but **do not count** for this requirement. --> 

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [ ] I ran the test suite and verified it succeeded
* [ ] I linked a GitHub issue to this PR (in the next section). 
* [ ] I have updated the changelog (if applicable)
* [ ] I have added or updated the documentation (if applicable)

## Related Issues/PRs

<!-- *Pick at least one. Delete the other lines.* -->

- This PR fixes/closes issue #
- This PR is related to issue #
- This PR depends on/blocks PR #