### PR TITLE
Fix systemd ordering cycle by moving go-hw-machine-id to early boot

### DIFF
--- a/wlanpi1-lite/02-go-hw-machine-id/files/wlanpi-go-hw-machine-id.service
+++ b/wlanpi1-lite/02-go-hw-machine-id/files/wlanpi-go-hw-machine-id.service
@@ -3,7 +3,6 @@ Description=Set machine-id from WLAN Pi Go hardware serial number
 DefaultDependencies=no
 After=local-fs.target expand-home-partition.service
 Before=sysinit.target systemd-machine-id-commit.service
-ConditionPathIsReadWrite=/etc
 RequiresMountsFor=/home
 
 [Service]

--- a/wlanpi1-lite/02-go-hw-machine-id/files/wlanpi-go-hw-machine-id.service
+++ b/wlanpi1-lite/02-go-hw-machine-id/files/wlanpi-go-hw-machine-id.service
@@ -1,13 +1,16 @@
 [Unit]
 Description=Set machine-id from WLAN Pi Go hardware serial number
-After=network.target multi-user.target
-Before=systemd-machine-id-commit.service
+DefaultDependencies=no
+After=local-fs.target expand-home-partition.service
+Before=sysinit.target systemd-machine-id-commit.service
+ConditionPathIsReadWrite=/etc
+RequiresMountsFor=/home
 
 [Service]
-Type=forking
+Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/bash -c '/usr/bin/sudo -u root /usr/local/sbin/go-hw-machine-id.sh'
+ExecStart=/usr/local/sbin/go-hw-machine-id.sh
 TimeoutSec=30
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sysinit.target


### PR DESCRIPTION
## Type of change 

<!--
Feel free to remove sections and items that don't pertain to the context of your PR.
For example, if you're updating docs, you don't need the testing section.
Note that you do not need to delete these HTML comments as they are not visible after the PR is submitted.
-->

<!-- *Pick at least one.* -->

* [X] Bug fix (non-breaking change that fixes something)
* [ ] Documentation update (readme, changelog, man page, etc.)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature changing existing functionality)
* [ ] Code quality improvement (refactor, performance improvements)
* [ ] Other (please specify):

## Breaking change

<!-- *Does this Pull Request introduce a breaking change?* -->

- What functionality breaks?
- Why does it break?
- How should it be migrated?  
- Are there any backward-compatible alternatives?

## Proposed change

<!-- *Please describe the purpose of this change, the problem it solves, and why the change is necessary. Including code snippets or links to related documentation when applicable will assist approval.* -->

Move go-hw-machine-id to early boot for proper machine-id initialization

Moves wlanpi-go-hw-machine-id.service from multi-user.target to sysinit.target to ensure machine-id is set before systemd-journald starts reading it.

Changes:

- Move to sysinit.target from multi-user.target for early boot execution
- Add DefaultDependencies=no to run before most system services
- Change Type from forking to oneshot (script doesn't background)
- Remove redundant sudo wrapper (service already runs as root)
- Add explicit dependency on expand-home-partition.service (needs /home expanded)
- Add RequiresMountsFor=/home (script writes to /home/.device-info)
- Keep Before=systemd-machine-id-commit.service to set machine-id early

The goal is for the Go hardware serial number to be used to set machine-id during early boot, providing consistent system identity across reboots and A/B partition switches.

## Testing

<!-- *Please explain how you tested this change manually, and if applicable, what new tests you added.* -->

- [ ] Did you add new automated tests? If yes, explain which edge cases are covered.
- [ ] Does this change affect any existing tests? If so, how did you adjust them?
- [ ] Please provide test run results or screenshots if applicable.

## LLM/AI usage

<!-- *Please disclose any use of LLMs or AI coding assistants in creating this PR.* -->

- [ ] I used an LLM or AI coding assistant for this PR
- If yes, please describe:
  - Which tool(s) and model(s) were used (e.g., Gemini 2.5 Flash, Claude 4.5 Sonnet, Copilot GPT-4, ChatGPT GPT-5)?
  - What portions of the code and PR were assisted?
  - Have you reviewed and tested all generated code for correctness?

## Checklist

<!-- No PR without a related GH issue! Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, homing pigeon, or slack are great starting points, but **do not count** for this requirement. --> 

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [ ] I ran the test suite and verified it succeeded
* [ ] I linked a GitHub issue to this PR (in the next section). 
* [ ] I have updated the changelog (if applicable)
* [ ] I have added or updated the documentation (if applicable)

## Related Issues/PRs

<!-- *Pick at least one. Delete the other lines.* -->

- This PR fixes/closes issue #
- This PR is related to issue #
- This PR depends on/blocks PR #