### PR TITLE
Move expand-home-partition to early boot in sysinit.target

### DIFF
--- a/scripts/ab-partition
+++ b/scripts/ab-partition
@@ -702,16 +702,19 @@ mkdir -p "$NEW_ROOTFS/etc/systemd/system"
 cat > "$NEW_ROOTFS/etc/systemd/system/expand-home-partition.service" << EOF
 [Unit]
 Description=Expand home partition to fill remaining disk
+DefaultDependencies=no
 After=local-fs.target
+Before=sysinit.target
 ConditionPathExists=!/etc/home-partition-expanded
+RequiresMountsFor=/home
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/sbin/expand-home-partition
 RemainAfterExit=yes
+ExecStart=/usr/local/sbin/expand-home-partition
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sysinit.target
 EOF
 
 mkdir -p "$NEW_ROOTFS/etc/systemd/system/multi-user.target.wants"


### PR DESCRIPTION
## Type of change 

<!--
Feel free to remove sections and items that don't pertain to the context of your PR.
For example, if you're updating docs, you don't need the testing section.
Note that you do not need to delete these HTML comments as they are not visible after the PR is submitted.
-->

<!-- *Pick at least one.* -->

* [X] Bug fix (non-breaking change that fixes something)
* [ ] Documentation update (readme, changelog, man page, etc.)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature changing existing functionality)
* [ ] Code quality improvement (refactor, performance improvements)
* [ ] Other (please specify):

## Breaking change

<!-- *Does this Pull Request introduce a breaking change?* -->

- What functionality breaks?
- Why does it break?
- How should it be migrated?  
- Are there any backward-compatible alternatives?

## Proposed change

<!-- *Please describe the purpose of this change, the problem it solves, and why the change is necessary. Including code snippets or links to related documentation when applicable will assist approval.* -->

Moves `expand-home-partition.service` from `multi-user.target` to `sysinit.target` to ensure the home partition is expanded before other early boot services attempt to write to `/home`.

Changes:

- Moved to `sysinit.target` from `multi-user.target` for early boot execution
- Added `DefaultDependencies=no` to prevent automatic conflicting dependencies
- Added `Before=sysinit.target` to ensure expansion completes during system initialization
- Added `RequiresMountsFor=/home` to make `/home` dependency clear

Why:

Several early boot services write to `/home`:

- `wlanpi-go-hw-machine-id.service` stores hardware serial in `/home/.device-info/`
- `wlanpi-persistent-identity.service` stores SSH keys in `/home/.persistent-identity/`

Running expand-home-partition in `multi-user.target` meant these services could run before the partition was expanded.

By moving to `sysinit.target`:

- Home partition is expanded (if needed) before any services write to it
- Proper ordering with other early boot services
- Clean dependency chain without cycles

## Testing

<!-- *Please explain how you tested this change manually, and if applicable, what new tests you added.* -->

- [ ] Did you add new automated tests? If yes, explain which edge cases are covered.
- [ ] Does this change affect any existing tests? If so, how did you adjust them?
- [ ] Please provide test run results or screenshots if applicable.

## LLM/AI usage

<!-- *Please disclose any use of LLMs or AI coding assistants in creating this PR.* -->

- [ ] I used an LLM or AI coding assistant for this PR
- If yes, please describe:
  - Which tool(s) and model(s) were used (e.g., Gemini 2.5 Flash, Claude 4.5 Sonnet, Copilot GPT-4, ChatGPT GPT-5)?
  - What portions of the code and PR were assisted?
  - Have you reviewed and tested all generated code for correctness?

## Checklist

<!-- No PR without a related GH issue! Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, homing pigeon, or slack are great starting points, but **do not count** for this requirement. --> 

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [ ] I ran the test suite and verified it succeeded
* [ ] I linked a GitHub issue to this PR (in the next section). 
* [ ] I have updated the changelog (if applicable)
* [ ] I have added or updated the documentation (if applicable)

## Related Issues/PRs

<!-- *Pick at least one. Delete the other lines.* -->

- This PR fixes/closes issue #
- This PR is related to issue #
- This PR depends on/blocks PR #