### PR TITLE
Use ConditionPathExists instead of ExecStartPre for first-boot guard

### DIFF
--- a/wlanpi1-lite/10-first-boot/files/lib/systemd/system/wlanpi-first-boot.service
+++ b/wlanpi1-lite/10-first-boot/files/lib/systemd/system/wlanpi-first-boot.service
@@ -3,10 +3,10 @@ Description=Script executed only once at the first boot to finish image configur
 After=network-online.target ufw.service local-fs.target
 Wants=network-online.target
 Requires=local-fs.target
+ConditionPathExists=!/var/lib/first-boot-done
 
 [Service]
 Type=oneshot
-ExecStartPre=/usr/bin/test ! -f /var/lib/first-boot-done
 ExecStart=/usr/bin/first-boot.sh
 ExecStartPost=touch /var/lib/first-boot-done
 RemainAfterExit=yes


### PR DESCRIPTION
## Type of change 

<!--
Feel free to remove sections and items that don't pertain to the context of your PR.
For example, if you're updating docs, you don't need the testing section.
Note that you do not need to delete these HTML comments as they are not visible after the PR is submitted.
-->

<!-- *Pick at least one.* -->

* [X] Bug fix (non-breaking change that fixes something)
* [ ] Documentation update (readme, changelog, man page, etc.)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature changing existing functionality)
* [ ] Code quality improvement (refactor, performance improvements)
* [ ] Other (please specify):

## Proposed change

<!-- *Please describe the purpose of this change, the problem it solves, and why the change is necessary. Including code snippets or links to related documentation when applicable will assist approval.* -->

Replace ExecStartPre test with ConditionPathExists to prevent the service from showing as "failed" on subsequent boots. Conditions skip the service cleanly when the marker file exists, avoiding unnecessary failure states in systemd status and logs.

## Testing

<!-- *Please explain how you tested this change manually, and if applicable, what new tests you added.* -->

Tested manually on WLAN Pi Go.

## LLM/AI usage

<!-- *Please disclose any use of LLMs or AI coding assistants in creating this PR.* -->

- [ ] I used an LLM or AI coding assistant for this PR
- If yes, please describe:
  - Which tool(s) and model(s) were used (e.g., Gemini 2.5 Flash, Claude 4.5 Sonnet, Copilot GPT-4, ChatGPT GPT-5)?
  - What portions of the code and PR were assisted?
  - Have you reviewed and tested all generated code for correctness?

## Checklist

<!-- No PR without a related GH issue! Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, homing pigeon, or slack are great starting points, but **do not count** for this requirement. --> 

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [ ] I ran the test suite and verified it succeeded
* [ ] I linked a GitHub issue to this PR (in the next section). 
* [ ] I have updated the changelog (if applicable)
* [ ] I have added or updated the documentation (if applicable)

## Related Issues/PRs

<!-- *Pick at least one. Delete the other lines.* -->

- This PR fixes/closes issue #
- This PR is related to issue #
- This PR depends on/blocks PR #