### PR TITLE
Remove double divert caused by firmware-mediatek

### DIFF
--- a/wlanpi2-full/02-net-tweaks/00-packages
+++ b/wlanpi2-full/02-net-tweaks/00-packages
@@ -5,7 +5,6 @@ iperf3
 wavemon
 firmware-atheros
 firmware-brcm80211
-firmware-mediatek
 firmware-misc-nonfree
 firmware-realtek
 raspberrypi-net-mods


### PR DESCRIPTION
## Summary

1. firmware-mediatek installed first and diverted:
   - BT_RAM_CODE_MT7922_1_1_hdr.bin → BT_RAM_CODE_MT7922_1_1_hdr.bin.usr-is-merged
   
2. wlanpi-misc-firmware then tried to divert the same file to a different location:
   - BT_RAM_CODE_MT7922_1_1_hdr.bin → BT_RAM_CODE_MT7922_1_1_hdr.bin.distro
   -
3. dpkg-divert rejected this because only ONE diversion is allowed per file path

Thus, we cannot ship firmware-mediatek. If we need any firmwares from firmware-mediatek, they need added to wlanpi-misc-firmware.

## Type of change

- [X] Bug fix
- [ ] New feature
- [X] Breaking change
- [ ] Documentation
- [ ] Other: 

## Proposed change

See summary

## Testing

<!-- How was this tested? -->
- [ ] Added/updated automated tests
- [ ] Tested manually on a WLAN Pi
- [ ] Tested in another environment

## AI assistance

- [ ] I used AI/LLM assistance
- If yes: Tool(s) used: 

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [X] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [ ] This PR fixes/closes issue #_ (or relates to issue #_)

## Breaking changes

<!-- Only fill out if you checked "Breaking change" above -->

- **What breaks:** firmware-mediatek
- **Migration needed:** Any firmwares we need from firmware-mediatek need added to wlanpi-misc-firmware
