### PR TITLE
Remove wlanpi-usb-ethernet from full image

### DIFF
--- a/wlanpi2-full/04-install-wlanpi-packages/00-packages
+++ b/wlanpi2-full/04-install-wlanpi-packages/00-packages
@@ -7,4 +7,3 @@ wlanpi-common
 wlanpi-wipry
 wlanpi-librespeed-cli
 wlanpi-misc-firmware
-wlanpi-usb-ethernet


### PR DESCRIPTION
## Summary

<!-- Briefly describe the change and why it's needed -->

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: 

## Proposed change

wlanpi-usb-ethernet causes gadget thrashing every 10 seconds on the M4/M4+ which resets the entire USB stack.

<!-- What problem does this solve? What was changed? -->

## Testing

<!-- How was this tested? -->
- [ ] Added/updated automated tests
- [X] Tested manually on a WLAN Pi
- [ ] Tested in another environment

## AI assistance

- [ ] I used AI/LLM assistance
- If yes: Tool(s) used: 

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [X] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [ ] This PR fixes/closes issue #_ (or relates to issue #_)

## Breaking changes

<!-- Only fill out if you checked "Breaking change" above -->

- **What breaks:** 
- **Migration needed:** 
