### PR TITLE
Load i2c-dev at boot for full image

### DIFF
--- a/wlanpi2-full/01-sys-tweaks/00-run.sh
+++ b/wlanpi2-full/01-sys-tweaks/00-run.sh
@@ -14,5 +14,8 @@ echo "root:root" | chpasswd
 
 # Add user to adm group for journalctl access
 usermod -aG adm ${FIRST_USER_NAME}
+
+# Load i2c module at boot
+echo "i2c-dev" >> /etc/modules
 EOF
 


### PR DESCRIPTION
## Summary

We need load `i2c-dev` at boot in order for i2c to work at boot.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: 

## Proposed change

Edit /etc/modules

<!-- What problem does this solve? What was changed? -->

## Testing

<!-- How was this tested? -->
- [ ] Added/updated automated tests
- [X] Tested manually on a WLAN Pi
- [ ] Tested in another environment

## AI assistance

- [ ] I used AI/LLM assistance
- If yes: Tool(s) used: 

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [ ] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [X] This PR fixes/closes issue #98

## Breaking changes

<!-- Only fill out if you checked "Breaking change" above -->

- **What breaks:** 
- **Migration needed:** 
