### PR TITLE
Add iftop to full image

### DIFF
--- a/wlanpi2-full/03-install-packages/00-packages
+++ b/wlanpi2-full/03-install-packages/00-packages
@@ -21,3 +21,4 @@ lm-sensors
 avahi-utils
 mtr-tiny
 tftpd-hpa
+iftop


### PR DESCRIPTION
## Summary

Adds iftop to full image

<!-- Briefly describe the change and why it's needed -->

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: 

## Testing

<!-- How was this tested? -->
- [ ] Added/updated automated tests
- [X] Tested manually on a WLAN Pi
- [ ] Tested in another environment

## AI assistance

- [ ] I used AI/LLM assistance
- If yes: Tool(s) used: 

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [ ] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [X] This PR closes #97 

## Breaking changes

<!-- Only fill out if you checked "Breaking change" above -->

- **What breaks:** 
- **Migration needed:** 
