### PR TITLE
Enable i2c_arm param in boot

### DIFF
--- a/wlanpi2-full/00-boot-files/files/config.txt
+++ b/wlanpi2-full/00-boot-files/files/config.txt
@@ -3,7 +3,7 @@
 # Some settings may impact device functionality. See link above for details
 
 # Uncomment some or all of these to enable the optional hardware interfaces
-#dtparam=i2c_arm=on
+dtparam=i2c_arm=on
 #dtparam=i2s=on
 dtparam=spi=on
 


### PR DESCRIPTION
## Summary

This is required for M4+ detection.

<!-- Briefly describe the change and why it's needed -->

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: 

## Proposed change

<!-- What problem does this solve? What was changed? -->

## Testing

<!-- How was this tested? -->
- [ ] Added/updated automated tests
- [X] Tested manually on a WLAN Pi
- [ ] Tested in another environment

## AI assistance

- [ ] I used AI/LLM assistance
- If yes: Tool(s) used: 

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [ ] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [ ] This PR fixes/closes issue #_ (or relates to issue #_)

## Breaking changes

<!-- Only fill out if you checked "Breaking change" above -->

- **What breaks:** 
- **Migration needed:** 
