### PR TITLE
Use dual kernel package (wlanpi-kernel-trixie) in the full image

### DIFF
--- a/wlanpi2-full/05-kernel/00-packages
+++ b/wlanpi2-full/05-kernel/00-packages
@@ -1,1 +1,1 @@
-wlanpi-kernel-trixie-v8
+wlanpi-kernel-trixie


### PR DESCRIPTION
`wlanpi2-full/00-boot-files/files/config.txt` selects `wlanpi-kernel_2712.img` under `[pi5]`/`[cm5]`, but `05-kernel/00-packages` installed `wlanpi-kernel-trixie-v8`, which only ships `wlanpi-kernel8.img`. So the full image would not boot on Pi 5/CM5.

Switch to the dual package `wlanpi-kernel-trixie` (just pushed to packagecloud as `7.1.2-v8-wlanpi+-20260710`), which ships both `wlanpi-kernel8.img` and `wlanpi-kernel_2712.img` in one deb, matching all four config.txt sections. Built as a single package upstream precisely to avoid DTB/overlay file conflicts between the per-variant debs.

wlanpi1-lite is left on `wlanpi-kernel-trixie-v8` (CM4-class hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)