### PR TITLE
Update actions to current majors (Node 20 deprecation)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
       codename: ${{ steps.version.outputs.codename }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 
 
@@ -211,7 +211,7 @@ jobs:
           
       - name: Upload collected job logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-os-${{ needs.build-prep.outputs.full_version }}_build-prep-job-logs 
           path: collected-logs/**/*.log
@@ -223,7 +223,7 @@ jobs:
       - build-prep
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up build dependencies
         run: |
@@ -499,26 +499,26 @@ jobs:
 
       - name: Upload full image
         if: ${{ github.event.inputs.skip_full_image != 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-os-${{ env.version }}-full
           path: processed/wlanpi-os*full*.img.gz
           if-no-files-found: ignore
 
       - name: Upload lite image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-os-${{ env.version }}-lite
           path: processed/wlanpi-os*lite*.img.gz
 
       - name: Upload digest (checksums)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-os-${{ env.version }}_digest
           path: processed/*.sha256
 
       - name: Upload info (included package versions)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-os-${{ env.version }}_infos
           path: |
@@ -536,7 +536,7 @@ jobs:
           
       - name: Upload collected job logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-os-${{ needs.build-prep.outputs.full_version }}_build-image-job-logs
           path: collected-logs/**/*.log
@@ -548,7 +548,7 @@ jobs:
     if: ${{ github.event.inputs.ab_partition == 'true' }}
     steps:
       - name: Checkout repository (for scripts)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         
       - name: Install required dependencies
         run: |
@@ -556,7 +556,7 @@ jobs:
           sudo apt-get install -y parted mount util-linux dosfstools rsync
 
       - name: Download lite image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wlanpi-os-${{ needs.build-prep.outputs.full_version }}-lite
           path: original-images
@@ -729,13 +729,13 @@ jobs:
           fi
 
       - name: Upload A/B partitioned image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-os-${{ needs.build-prep.outputs.full_version }}-lite-AB_PARTITION
           path: ab-partitioned/*.img.gz
           
       - name: Upload A/B partitioned image checksums
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-os-${{ needs.build-prep.outputs.full_version }}-lite-AB_PARTITION-sha256
           path: ab-partitioned/*.sha256
@@ -751,7 +751,7 @@ jobs:
           
       - name: Upload collected job logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-os-${{ needs.build-prep.outputs.full_version }}_ab-partition-image-job-logs  
           path: collected-logs/**/*.log
@@ -768,13 +768,13 @@ jobs:
         run: echo "This job only runs on the default branch"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: '0'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: all-artifacts
 
@@ -868,7 +868,7 @@ jobs:
           
       - name: Upload collected job logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-os-${{ needs.build-prep.outputs.full_version }}_release-job-logs 
           path: collected-logs/**/*.log
@@ -884,7 +884,7 @@ jobs:
     if: ${{ always() }}
     steps:
       - name: Download all log artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: "*-logs"
           path: all-logs
@@ -914,7 +914,7 @@ jobs:
           done
 
       - name: Upload combined logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-os-${{ needs.build-prep.outputs.full_version }}-github-logs
           path: "combined-logs/**/*.log"


### PR DESCRIPTION
Bumps `actions/checkout` v4 → v7, `actions/upload-artifact` v4 → v7, and `actions/download-artifact` v4 → v8 in build.yml to clear the Node 20 deprecation warnings. All three use the same artifact-service API, so upload/download interoperate across the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)