### PR TITLE
Fix fork bugs and adopt upstream fixes from divergence audit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -y update && \
     apt-get -y install --no-install-recommends \
         git vim parted \
-        quilt coreutils qemu-user-static debootstrap zerofree zip dosfstools \
+        quilt coreutils qemu-user-static debootstrap zerofree zip dosfstools e2fsprogs \
         libarchive-tools libcap2-bin rsync grep udev xz-utils curl xxd file kmod bc \
         binfmt-support ca-certificates fdisk gpg pigz arch-test \
     && rm -rf /var/lib/apt/lists/*

--- a/build.sh
+++ b/build.sh
@@ -68,6 +68,8 @@ EOF
 			log "Begin ${SUB_STAGE_DIR}/${i}-run.sh"
 			./${i}-run.sh
 			log "End ${SUB_STAGE_DIR}/${i}-run.sh"
+		elif [ -f ${i}-run.sh ]; then
+			log "Skip ${SUB_STAGE_DIR}/${i}-run.sh (not executable)"
 		fi
 		if [ -f ${i}-run-chroot.sh ]; then
 			log "Begin ${SUB_STAGE_DIR}/${i}-run-chroot.sh"
@@ -378,6 +380,7 @@ if [ "$SKIP_FULL_IMAGE" = "true" ]; then
             FILTERED_STAGE_LIST+="$stage"
         fi
     done
+    STAGE_LIST="$FILTERED_STAGE_LIST"
 fi
 export STAGE_LIST
 

--- a/depends
+++ b/depends
@@ -6,6 +6,7 @@ debootstrap
 zerofree
 zip
 mkdosfs:dosfstools
+mke2fs:e2fsprogs
 capsh:libcap2-bin
 bsdtar:libarchive-tools
 grep

--- a/export-image/00-allow-rerun/00-run.sh
+++ b/export-image/00-allow-rerun/00-run.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -e
 
-if [ ! -x "${ROOTFS_DIR}/usr/bin/qemu-arm-static" ]; then
-	cp /usr/bin/qemu-arm-static "${ROOTFS_DIR}/usr/bin/"
-fi
-
 if [ -e "${ROOTFS_DIR}/etc/ld.so.preload" ]; then
 	mv "${ROOTFS_DIR}/etc/ld.so.preload" "${ROOTFS_DIR}/etc/ld.so.preload.disabled"
 fi

--- a/export-image/05-finalise/01-run.sh
+++ b/export-image/05-finalise/01-run.sh
@@ -13,6 +13,10 @@ fi
 if hash hardlink 2>/dev/null; then
 	hardlink -t /usr/share/doc
 fi
+if [ -f /usr/lib/systemd/system/apt-listchanges.service ]; then
+	python3 -m apt_listchanges.populate_database --profile apt
+	systemctl disable apt-listchanges.timer
+fi
 EOF
 
 if [ -f "${ROOTFS_DIR}/etc/initramfs-tools/update-initramfs.conf" ]; then
@@ -23,8 +27,6 @@ fi
 if [ -d "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/.config" ]; then
 	chmod 700 "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/.config"
 fi
-
-rm -f "${ROOTFS_DIR}/usr/bin/qemu-arm-static"
 
 if [ "${USE_QEMU}" != "1" ]; then
 	if [ -e "${ROOTFS_DIR}/etc/ld.so.preload.disabled" ]; then

--- a/scripts/common
+++ b/scripts/common
@@ -34,6 +34,9 @@ bootstrap(){
 		return 1
 	fi
 
+	# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1050719
+	rm -f wget-log*
+
 	if [ -d "$2/debootstrap" ] && ! rmdir "$2/debootstrap"; then
 		cp "$2/debootstrap/debootstrap.log" "${STAGE_WORK_DIR}"
 		log "bootstrap failed: please check ${STAGE_WORK_DIR}/debootstrap.log"


### PR DESCRIPTION
Follow-up to the upstream-divergence audit. Three fork bugs, three upstream adoptions.

## Fork bugs

- **`SKIP_FULL_IMAGE` was a no-op**: `build.sh` built `FILTERED_STAGE_LIST` but never assigned it back to `STAGE_LIST`, which the stage loop iterates. Now assigned.
- **Silent skip of non-executable run scripts**: a `NN-run.sh` without `+x` simply vanished from the build. Adopted upstream's `log "Skip ... (not executable)"` branch so it's visible.
- **armhf emulator in an arm64 image**: `export-image/00-allow-rerun` copied `qemu-arm-static` into the rootfs (and `05-finalise` removed it again). Pointless on arm64, and the `bash -e` script failed the whole export on hosts without the binary. Both sides removed.

## Adopted from upstream

- `depends` + `Dockerfile`: add `mke2fs:e2fsprogs` — e2fsprogs is no longer guaranteed present on trixie hosts, and `export-image/prerun.sh` runs `mkfs.ext4`.
- `05-finalise`: populate the apt-listchanges database and disable its timer at finalise (guarded on the service existing). The full image installs apt-listchanges; without this, users get every historical changelog on their first upgrade.
- `scripts/common`: restore the `rm -f wget-log*` debootstrap workaround (Debian bug [#1050719](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1050719)) that was lost in the error-handling rewrite.

Deliberately **not** adopted (intentional divergence): 8 MB partition alignment (A/B partition math depends on 4 MB), `TEMP_REPO`/`ENABLE_CLOUD_INIT`/`PASSWORDLESS_SUDO`, systemd-timesync clock init (fork uses fake-hwclock).

All scripts pass `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)