### PR TITLE
Resolve latest wireless-regdb at build time (pinned pool URL 404s)

### DIFF
--- a/wlanpi1-lite/07-config-files/00-run.sh
+++ b/wlanpi1-lite/07-config-files/00-run.sh
@@ -1,5 +1,15 @@
 #!/bin/bash -e
 
+# Resolve the latest wireless-regdb from the Debian pool at build time;
+# a pinned filename 404s whenever the pool rotates to a new version
+REGDB_POOL="https://deb.debian.org/debian/pool/main/w/wireless-regdb/"
+REGDB_DEB="$(curl -s "${REGDB_POOL}" | grep -oE 'wireless-regdb_[0-9.]+-[0-9]+_all\.deb' | sort -uV | tail -n1)"
+if [ -z "${REGDB_DEB}" ]; then
+	echo "ERROR: could not determine latest wireless-regdb from ${REGDB_POOL}"
+	exit 1
+fi
+echo "Using wireless-regdb: ${REGDB_DEB}"
+
 on_chroot <<CHEOF
 	# Set retry for dhclient
 	if grep -q -E "^#?retry " /etc/dhcp/dhclient.conf; then
@@ -36,7 +46,7 @@ on_chroot <<CHEOF
 	update-pciids
 
 	# Install wireless-regdb
-	wget -O /tmp/wireless-regdb.deb http://ftp.us.debian.org/debian/pool/main/w/wireless-regdb/wireless-regdb_2025.10.07-1_all.deb
+	wget -O /tmp/wireless-regdb.deb ${REGDB_POOL}${REGDB_DEB}
 	dpkg -i /tmp/wireless-regdb.deb
 	rm -f /tmp/wireless-regdb.deb
 	update-alternatives --set regulatory.db /lib/firmware/regulatory.db-upstream

--- a/wlanpi2-full/07-config-files/00-run.sh
+++ b/wlanpi2-full/07-config-files/00-run.sh
@@ -1,5 +1,15 @@
 #!/bin/bash -e
 
+# Resolve the latest wireless-regdb from the Debian pool at build time;
+# a pinned filename 404s whenever the pool rotates to a new version
+REGDB_POOL="https://deb.debian.org/debian/pool/main/w/wireless-regdb/"
+REGDB_DEB="$(curl -s "${REGDB_POOL}" | grep -oE 'wireless-regdb_[0-9.]+-[0-9]+_all\.deb' | sort -uV | tail -n1)"
+if [ -z "${REGDB_DEB}" ]; then
+	echo "ERROR: could not determine latest wireless-regdb from ${REGDB_POOL}"
+	exit 1
+fi
+echo "Using wireless-regdb: ${REGDB_DEB}"
+
 # Copy default avahi ssh.service
 [[ -f "${ROOTFS_DIR}"/usr/share/doc/avahi-daemon/examples/ssh.service ]] && \
 cp "${ROOTFS_DIR}"/usr/share/doc/avahi-daemon/examples/ssh.service "${ROOTFS_DIR}"/etc/avahi/services/
@@ -63,7 +73,7 @@ on_chroot <<CHEOF
 	update-pciids
 
 	# Install wireless-regdb
-	wget -O /tmp/wireless-regdb.deb http://ftp.us.debian.org/debian/pool/main/w/wireless-regdb/wireless-regdb_2025.10.07-1_all.deb
+	wget -O /tmp/wireless-regdb.deb ${REGDB_POOL}${REGDB_DEB}
 	dpkg -i /tmp/wireless-regdb.deb
 	rm -f /tmp/wireless-regdb.deb
 	update-alternatives --set regulatory.db /lib/firmware/regulatory.db-upstream


### PR DESCRIPTION
Fixes the build failure:

```
http://ftp.us.debian.org/debian/pool/main/w/wireless-regdb/wireless-regdb_2025.10.07-1_all.deb
ERROR 404: Not Found.
```

Debian's pool only keeps the current version — the pinned `2025.10.07-1` deb vanished when `2026.05.30-1` superseded it, and any new pin will break the same way at the next regdb release.

Both stages (`wlanpi1-lite` and `wlanpi2-full` `07-config-files/00-run.sh`) now resolve the current filename from the pool index at build time on the host, fail with a clear error if resolution fails, and interpolate the resolved URL into the chroot heredoc (unquoted `<<CHEOF`, so host-side expansion applies). Also switched `ftp.us.debian.org` → `deb.debian.org` (CDN).

Verified against the live pool: resolves to `wireless-regdb_2026.05.30-1_all.deb`, HTTP 200. Both scripts pass `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)